### PR TITLE
DAPA-7 - Implement basic token retrieval endpoint (public access)

### DIFF
--- a/app/routes/git_tokens.py
+++ b/app/routes/git_tokens.py
@@ -97,7 +97,8 @@ async def get_token_by_label(label:str) ->List[Dict[str, Any]]:
     try:
         client = SupabaseClient()
         res = client.filter(table="git_label",filters={"label": label}, limit=1)
-        formatted_tokens = [format_token_response(token) for token in res]
+        formatted_tokens = [t for t in (format_token_response(token) for token in res) if t]
+
         return formatted_tokens
     except Exception as e:
         raise HTTPException(

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
-import unittest
 import coverage
 import os
 import sys
+import pytest
 
 # Start code coverage collection
 cov = coverage.Coverage(
@@ -15,16 +15,15 @@ cov = coverage.Coverage(
 )
 cov.start()
 
-# Discover and run tests
-loader = unittest.TestLoader()
-start_dir = "tests"
-pattern = "test_*.py"
+# Run pytest
+pytest_args = [
+    "tests",               # test directory
+    "-v",                  # verbose
+    "--tb=short",          # shorter traceback
+]
+exit_code = pytest.main(pytest_args)
 
-suite = loader.discover(start_dir, pattern=pattern)
-runner = unittest.TextTestRunner(verbosity=2)
-result = runner.run(suite)
-
-# Stop coverage and generate report
+# Stop coverage and generate reports
 cov.stop()
 cov.save()
 
@@ -38,15 +37,15 @@ if not os.path.exists(cov_dir):
     os.makedirs(cov_dir)
 cov.html_report(directory=cov_dir)
 
-# Generate XML report for SonarQube - removed unsupported parameter
+# Generate XML report for SonarQube
 cov.xml_report(outfile="coverage.xml")
 
 print(f"\nHTML coverage report generated in {cov_dir}/")
 print(f"XML coverage report generated in coverage.xml")
 
-# Show coverage path for debugging
+# Show absolute path for debugging
 coverage_file = os.path.abspath("coverage.xml")
 print(f"Absolute path to coverage report: {coverage_file}")
 
-# Return non-zero exit code if tests failed
-sys.exit(not result.wasSuccessful())
+# Exit with pytest's exit code
+sys.exit(exit_code)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ Pytest fixtures for token API endpoint tests.
 
 import pytest
 from fastapi.testclient import TestClient
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from app.main import app  # Assuming your FastAPI app is in app.main
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,87 @@
+"""
+Pytest fixtures for token API endpoint tests.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import MagicMock, patch
+
+from app.main import app  # Assuming your FastAPI app is in app.main
+
+# Sample encrypted token values for testing
+TOKEN_ENCRYPTED_1 = "gAAAAABoLCptgspZg0h7yQRjfAJhWWKHLsKl5IL8qKnP4mH4TDq-6TlZI_94TMWCftEUU65eYAlz0e0_gQI4pKwOIEoqHEqtxOuzHEIvwTJRtaVi1nQZm4Y="
+TOKEN_ENCRYPTED_2 = "gAAAAABoLCptgspZg0h7yQRjfAJhWWKHLsKl5IL8qKnP4mH4TDq-6TlZI_94TMWCftEUU65eYAlz0e0_gQI4pKwOIEoqHEqtxOuzHEIvwTJRtaVi1nQZm4Y="
+
+@pytest.fixture
+def client():
+    """
+    Create and return a test client for the FastAPI app.
+    """
+    return TestClient(app)
+
+@pytest.fixture
+def mock_supabase():
+    """
+    Create a mocked Supabase client.
+    """
+    with patch('app.routes.git_tokens.SupabaseClient') as mock:
+        yield mock
+
+@pytest.fixture
+def mock_encryption_helper():
+    """
+    Create a mocked EncryptionHelper.
+    """
+    with patch('app.routes.git_tokens.EncryptionHelper') as mock:
+        # Configure decrypt method to return predictable values for tests
+        mock.decrypt.side_effect = lambda token: "ghp_1234567890abcdef" if token else ""
+        yield mock
+
+@pytest.fixture
+def token_data_single():
+    """
+    Return a single token data record for testing.
+    """
+    return {
+        "id": "123",
+        "label": "Production GitHub",
+        "git_hosting": "github",
+        "token_value": TOKEN_ENCRYPTED_1,
+        "created_at": "2024-01-01T10:00:00Z",
+        "updated_at": "2024-01-02T10:00:00Z"
+    }
+
+@pytest.fixture
+def token_data_list():
+    """
+    Return a list of token data records for testing.
+    """
+    return [
+        {
+            "id": "1",
+            "label": "GitHub Production",
+            "git_hosting": "github",
+            "token_value": TOKEN_ENCRYPTED_1,
+            "created_at": "2024-01-01T10:00:00Z",
+            "updated_at": "2024-01-02T10:00:00Z"
+        },
+        {
+            "id": "2",
+            "label": "GitLab Staging",
+            "git_hosting": "gitlab",
+            "token_value": TOKEN_ENCRYPTED_2,
+            "created_at": "2024-01-03T10:00:00Z",
+            "updated_at": "2024-01-04T10:00:00Z"
+        }
+    ]
+
+@pytest.fixture
+def mock_supabase_select(mock_supabase, token_data_list):
+    """
+    Setup the mock Supabase client to return token data list.
+    """
+    print("mock_supabase_select", token_data_list)
+    mock_instance = mock_supabase.return_value
+    mock_instance.select.return_value = token_data_list
+    return mock_instance
+

--- a/tests/test_token_api.py
+++ b/tests/test_token_api.py
@@ -82,7 +82,7 @@ class TestTokenFormatting:
         result = format_token_response(token_data)
         assert result is None
 
-        def test_format_token_response_empty_token(self, mock_encryption_helper):
+    def test_format_token_response_empty_token(self, mock_encryption_helper):
             """Test formatting with empty token value."""
 
             token_data = {
@@ -101,11 +101,11 @@ class TestTokenFormatting:
 
             result = format_token_response(token_data)
 
-            assert result is not None
+            assert result is  None
 
-            assert result["token_value"] == ""
 
-        def test_format_token_response_none_input(self):
+
+    def test_format_token_response_none_input(self):
             """Test formatting with None input."""
 
             result = format_token_response(None)

--- a/tests/test_token_api.py
+++ b/tests/test_token_api.py
@@ -2,7 +2,6 @@
 Test cases for token retrieval and creation API endpoints.
 """
 
-import pytest
 from fastapi import status
 from app.routes.git_tokens import mask_token, format_token_response
 
@@ -123,10 +122,8 @@ class TestGetTokensEndpoint:
         response = client.get("/api/v1/git_tokens/")
 
         # Verify response
-        print("mock_supabase_select.filter.return_value ", mock_supabase_select.select.return_value)
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
-        print("data ", data)
         assert len(data) == 2
 
         # Verify first token
@@ -210,8 +207,6 @@ class TestGetTokensEndpoint:
 
         # Make request
         response = client.get("/api/v1/git_tokens/")
-        print("response.status_code  ", response.status_code )
-        print("data ", response.json())
 
         # Verify error response
         assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
@@ -307,7 +302,6 @@ class TestGetTokenByLabelEndpoint:
         assert response.status_code == status.HTTP_200_OK
 
         data = response.json()
-        print("data line 310 ", data)
 
         # Since format_token_response returns None for invalid data, we should get an empty list
 

--- a/tests/test_token_api.py
+++ b/tests/test_token_api.py
@@ -1,0 +1,149 @@
+"""
+Test cases for token retrieval and creation API endpoints.
+"""
+
+import pytest
+from fastapi import status
+from app.routes.git_tokens import mask_token, format_token_response
+
+class TestTokenMasking:
+    """Test cases for token masking functionality."""
+
+    def test_mask_token_normal_length(self):
+        """Test masking for normal length token."""
+        token = "ghp_1234567890abcdef"
+        result = mask_token(token)
+        assert result == "ghp_************cdef"
+        assert len(result) == len(token)
+
+    def test_mask_token_short_token(self):
+        """Test masking for short token (8 chars or less)."""
+        token = "short123"
+        result = mask_token(token)
+        assert result == "********"
+        assert len(result) == len(token)
+
+    def test_mask_token_empty_string(self):
+        """Test masking for empty token."""
+        token = ""
+        result = mask_token(token)
+        assert result == ""
+
+    def test_mask_token_none(self):
+        """Test masking for None token."""
+        token = None
+        result = mask_token(token)
+        assert result == ""
+
+
+class TestTokenFormatting:
+    """Test cases for token response formatting."""
+
+    def test_format_token_response_complete(self, token_data_single, mock_encryption_helper):
+        """Test formatting with all fields present."""
+        result = format_token_response(token_data_single)
+
+        assert result["id"] == "123"
+        assert result["label"] == "Production GitHub"
+        assert result["git_hosting"] == "github"
+        assert result["token_value"] == "ghp_************cdef"
+        assert result["created_at"] == "2024-01-01T10:00:00Z"
+        assert result["updated_at"] == "2024-01-02T10:00:00Z"
+
+    def test_format_token_response_missing_fields(self):
+        """Test formatting with missing fields."""
+        token_data = {
+            "id": "123",
+            "label": "Test Token"
+            # Missing token_value field
+        }
+
+        result = format_token_response(token_data)
+        assert not result
+
+
+class TestGetTokensEndpoint:
+    """Test cases for GET /api/tokens endpoint."""
+
+    def test_successful_token_retrieval(self, client, mock_supabase_select, mock_encryption_helper):
+        """Test successful retrieval of tokens."""
+        # Make the request
+        response = client.get("/api/v1/git_tokens/")
+
+        # Verify response
+        print("mock_supabase_select.filter.return_value ", mock_supabase_select.select.return_value)
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        print("data ", data)
+        assert len(data) == 2
+
+        # Verify first token
+        token1 = data[0]
+        assert token1["id"] == "1"
+        assert token1["label"] == "GitHub Production"
+        assert token1["git_hosting"] == "github"
+        assert token1["token_value"] == "ghp_************cdef"
+        assert token1["created_at"] == "2024-01-01T10:00:00Z"
+
+        # Verify second token
+        token2 = data[1]
+        assert token2["id"] == "2"
+        assert token2["label"] == "GitLab Staging"
+        assert token2["git_hosting"] == "gitlab"
+        assert token2["token_value"] == "ghp_************cdef"
+
+        # Verify supabase was called correctly
+        mock_supabase_select.select.assert_called_once_with(
+            table="git_label",
+            columns="label, id, git_hosting,token_value, created_at"
+        )
+
+    def test_empty_token_list(self, client, mock_supabase):
+        """Test retrieval when no tokens exist."""
+        # Mock empty database response
+        mock_instance = mock_supabase.return_value
+        mock_instance.select.return_value = []
+
+        # Make request
+        response = client.get("/api/v1/git_tokens/")
+
+        # Verify response
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data == []
+        assert isinstance(data, list)
+
+        # Verify supabase was called
+        mock_instance.select.assert_called_once()
+
+    def test_database_connection_error(self, client, mock_supabase):
+        """Test error handling when database connection fails."""
+        # Mock database error
+        mock_instance = mock_supabase.return_value
+        mock_instance.select.side_effect = Exception("Database connection failed")
+
+        # Make request
+        response = client.get("/api/v1/git_tokens/")
+
+        # Verify error response
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        data = response.json()
+        assert "detail" in data
+        assert "Service temporarily unavailable. Please try again later." in data["detail"]
+
+    def test_database_timeout_error(self, client, mock_supabase):
+        """Test error handling for database timeout."""
+        # Mock timeout error
+        mock_instance = mock_supabase.return_value
+        mock_instance.select.side_effect = TimeoutError("Database timeout")
+
+        # Make request
+        response = client.get("/api/v1/git_tokens/")
+        print("response.status_code  ", response.status_code )
+        print("data ", response.json())
+
+        # Verify error response
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        data = response.json()
+        assert "Service temporarily unavailable. Please try again later" in data["detail"]
+


### PR DESCRIPTION
Remove unused model AddGitlab and improve token route handling.

The AddGitlab model and its references were removed as they were no longer in use. Enhanced the `get_all_tokens` route with proper exception handling and filtering of invalid token data. Updated route metadata for better accuracy and clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Added comprehensive automated tests for token-related API endpoints, including token masking, formatting, and retrieval scenarios.
	- Introduced fixtures and mocks to support isolated and reliable testing of API behavior and error handling.
- **Chores**
	- Updated the test runner to use pytest for improved test discovery and execution.
- **Bug Fixes**
	- Improved token retrieval to exclude invalid or improperly formatted tokens from API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->