### PR TITLE
fix!: change 'SUPABASE_KEY' environment variable name to 'SUPABASE_SECRET_KEY'

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ SECRET_KEY=your-secret-key-here
 
 # Supabase configuration
 SUPABASE_URL=https://your-project-id.supabase.co
-SUPABASE_KEY=your-supabase-key
+SUPABASE_SECRET_KEY=your-supabase-key
 
 # Clerk configuration
 CLERK_API_KEY=your-clerk-api-key

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ my_flask_supabase_app/
 4. Create a `.env` file in the root directory with your credentials:
    ```
    SUPABASE_URL=https://your-supabase-project.supabase.co
-   SUPABASE_KEY=your-supabase-key
+   SUPABASE_SECRET_KEY=your-supabase-key
    CLERK_API_KEY=your-clerk-api-key
    ```
 

--- a/app/config.py
+++ b/app/config.py
@@ -22,7 +22,7 @@ class Settings(BaseSettings):
 
     #supbase settings
     SUPABASE_URL: str = "https://localhost"
-    SUPABASE_KEY: str = "test-supabase-key"
+    SUPABASE_SECRET_KEY: str = "test-supabase-key"
     CLERK_API_KEY: str = "test-clerk-key"
 
     CLERK_JWT_PUBLIC_KEY: Optional[str] = None

--- a/app/services/supabase_client.py
+++ b/app/services/supabase_client.py
@@ -17,10 +17,10 @@ class SupabaseClient:
         
         Args:
             url (str, optional): Supabase project URL. Defaults to settings.SUPABASE_URL.
-            key (str, optional): Supabase API key. Defaults to settings.SUPABASE_KEY.
+            key (str, optional): Supabase API key. Defaults to settings.SUPABASE_SECRET_KEY.
         """
         self.url = url or settings.SUPABASE_URL
-        self.key = key or settings.SUPABASE_KEY
+        self.key = key or settings.SUPABASE_SECRET_KEY
         self.headers = {
             "apikey": self.key,
             "Authorization": f"Bearer {self.key}",


### PR DESCRIPTION
Changed the name of the environment variable `SUPABASE_KEY` to become `SUPABASE_SECRET_KEY` wherever it's relevant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated environment variable name in setup instructions and example file to improve clarity.
- **Chores**
  - Renamed the Supabase API key environment variable for consistency across configuration and service files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->