### PR TITLE
DAPA-25 Add pytest to GitHub Actions for Automated Testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Run tests and generate coverage
         run: |
-          coverage run -m unittest discover tests
+          coverage run -m pytest tests
           coverage xml
 
       - name: SonarQube Scan

--- a/app/config.py
+++ b/app/config.py
@@ -18,7 +18,7 @@ class Settings(BaseSettings):
     # API configuration
     API_ENV: str = "development"
     API_DEBUG: bool = True
-    SECRET_KEY: str = "dev-secret-key"  # Only for local/testing
+    SECRET_KEY: str = "f2hCPmuCDiBpAmuZD00ZX4fEXFb-H0WoReklDhJD3bA="  # Only for local/testing
 
     #supbase settings
     SUPABASE_URL: str = "https://localhost"
@@ -37,6 +37,8 @@ class Settings(BaseSettings):
     # SonarQube configuration
     SONARQUBE_URL: Optional[str] = None
     SONARQUBE_TOKEN: Optional[str] = None
+
+    LAUNCHDARKLY_SDK_KEY: Optional[str] = None
 
     #Version
     VERSION: str = "0.1.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,8 +11,9 @@ from app.main import app  # Assuming your FastAPI app is in app.main
 
 # Sample encrypted token values for testing
 #TOKEN_ENCRYPTED_1 = "gAAAAABoLCptgspZg0h7yQRjfAJhWWKHLsKl5IL8qKnP4mH4TDq-6TlZI_94TMWCftEUU65eYAlz0e0_gQI4pKwOIEoqHEqtxOuzHEIvwTJRtaVi1nQZm4Y="
-TOKEN_ENCRYPTED_1 = "gAAAAABoLY1xN44144aj4hoqxlP1A385SKuWONI-ydywxS2M8UHpxMu71CHXhu3rDruewrLeAV-jMiQAp0F8i5a5f9yv06QScbeV0yqI_rFN6B3HYsIZnMs="
-TOKEN_ENCRYPTED_2 = "gAAAAABoLY1VLHmjiBQ1QMt1nG9PcKxdGHjDK1QzsZHwo7-7WZv8uFfTbZikYZcizmkHWl9SwEcuSYXVogoCABLXfrIvmD3u3hnUxVqw9fo6eZeB8TrJDNE="
+TOKEN_ENCRYPTED_1 = "gAAAAABoMFiNIvAc7WIFnoKXBjkpAVrdiTFrhlmZtG8BBwvmy1dtvfEFmupm0fcvDUo3unosoAQz5eclP2QFMnPMLG4Hj21MBt-xTdWL661JnWP-wQarnLI="
+TOKEN_ENCRYPTED_2 = "gAAAAABoMFiNIvAc7WIFnoKXBjkpAVrdiTFrhlmZtG8BBwvmy1dtvfEFmupm0fcvDUo3unosoAQz5eclP2QFMnPMLG4Hj21MBt-xTdWL661JnWP-wQarnLI="
+
 
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the workflow to use pytest for running tests and generating coverage reports.
  - Enhanced default security configuration with a stronger secret key and added support for a new optional feature flag integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->