### PR TITLE
DAPA-26 remove unused function

### DIFF
--- a/app/routes/git_tokens.py
+++ b/app/routes/git_tokens.py
@@ -91,29 +91,6 @@ def mask_token(token: str) -> str:
     return f"{prefix}{middle_mask}{suffix}"
 
 
-def format_token_response(token_data: Dict[str, Any]) -> Dict[str, Any]:
-    """
-    Formats raw token data by decrypting and masking the token value for API responses.
-    
-    If the token value is present, returns a dictionary containing the token's metadata and a masked version of the decrypted token value. Returns False if the token value is missing.
-    """
-
-    if token_data and token_data.get("token_value"):
-        try:
-            decrypt_data = EncryptionHelper.decrypt(token_data.get("token_value", ""))
-        except Exception as e:
-            print(f"Error decrypting token value: {e}")
-            return False
-        return {
-            "id": token_data.get("id"),
-            "label": token_data.get("label"),
-            "git_hosting": token_data.get("git_hosting"),
-            "token_value": mask_token(decrypt_data),
-            "created_at": token_data.get("created_at"),
-            "updated_at": token_data.get("updated_at")
-        }
-    else:
-        return None
 # Create router
 router = APIRouter()
 
@@ -160,10 +137,8 @@ async def get_token_by_label(label:str) ->List[Dict[str, Any]]:
     """
     try:
         client = SupabaseClient()
-        res = client.filter(table="git_label",filters={"label": label}, limit=1)
-        formatted_tokens = [t for t in (format_token_response(token) for token in res) if t]
-
-        return formatted_tokens
+        res = client.filter(table="git_label",filters={"label": label}, columns="label, id, git_hosting,masked_token, created_at")
+        return res
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/app/routes/git_tokens.py
+++ b/app/routes/git_tokens.py
@@ -137,7 +137,7 @@ async def get_token_by_label(label:str) ->List[Dict[str, Any]]:
     """
     try:
         client = SupabaseClient()
-        res = client.filter(table="git_label",filters={"label": label}, columns="label, id, git_hosting,masked_token, created_at")
+        res = client.filter(table="git_label",filters={"label": label}, columns="label, id, git_hosting, masked_token, created_at")
         return res
     except Exception as e:
         raise HTTPException(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from app.main import app  # Assuming your FastAPI app is in app.main
 #TOKEN_ENCRYPTED_1 = "gAAAAABoLCptgspZg0h7yQRjfAJhWWKHLsKl5IL8qKnP4mH4TDq-6TlZI_94TMWCftEUU65eYAlz0e0_gQI4pKwOIEoqHEqtxOuzHEIvwTJRtaVi1nQZm4Y="
 TOKEN_ENCRYPTED_1 = "gAAAAABoMFiNIvAc7WIFnoKXBjkpAVrdiTFrhlmZtG8BBwvmy1dtvfEFmupm0fcvDUo3unosoAQz5eclP2QFMnPMLG4Hj21MBt-xTdWL661JnWP-wQarnLI="
 TOKEN_ENCRYPTED_2 = "gAAAAABoMFiNIvAc7WIFnoKXBjkpAVrdiTFrhlmZtG8BBwvmy1dtvfEFmupm0fcvDUo3unosoAQz5eclP2QFMnPMLG4Hj21MBt-xTdWL661JnWP-wQarnLI="
-
+decrypted1_masked=decrypted2_masked="ghp_************cdef"
 
 
 
@@ -80,6 +80,7 @@ def token_data_list():
             "label": "GitHub Production",
             "git_hosting": "github",
             "token_value": TOKEN_ENCRYPTED_1,
+            "masked_token": decrypted1_masked,
             "created_at": "2024-01-01T10:00:00Z",
             "updated_at": "2024-01-02T10:00:00Z"
         },
@@ -88,6 +89,7 @@ def token_data_list():
             "label": "GitLab Staging",
             "git_hosting": "gitlab",
             "token_value": TOKEN_ENCRYPTED_2,
+            "masked_token":decrypted2_masked,
             "created_at": "2024-01-03T10:00:00Z",
             "updated_at": "2024-01-04T10:00:00Z"
         }
@@ -233,6 +235,11 @@ def mock_supabase_invalid_data(mock_supabase, invalid_token_data_list):
 
     return mock_instance
 
+
+@pytest.fixture()
+def mock_supabase_invalid_label(mock_supabase):
+    mock_supabase.filter.return_value = []
+    return mock_supabase
 
 @pytest.fixture
 def mock_github_manager():


### PR DESCRIPTION
Remove unused token formatting function and streamline API response

The `format_token_response` function was removed as it was no longer used. API responses for `git_label` now directly return relevant fields from the database, improving efficiency and reducing unnecessary processing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified token retrieval by label, removing extra decryption and masking steps from the API.
- **Chores**
  - Removed internal token formatting logic and updated tests to reflect use of masked tokens only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->