### PR TITLE
DAPA-43 Hide webhooks endpoint from OpenAPI documentation

### DIFF
--- a/app/routes/webhooks.py
+++ b/app/routes/webhooks.py
@@ -12,7 +12,7 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-@router.post("/", status_code=status.HTTP_200_OK)
+@router.post("/", status_code=status.HTTP_200_OK, include_in_schema=False)
 async def webhook_handler(request: Request, response: Response):
     """
     Handle Clerk webhook events for user management.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- The webhook endpoint is now hidden from the public API documentation, but its functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->