### PR TITLE
feat: Added `relative_path` handling for `gitlab` and `github` Operations

### DIFF
--- a/devdox/app/models/repo.py
+++ b/devdox/app/models/repo.py
@@ -20,6 +20,7 @@ class Repo(Model):
     repo_name = fields.CharField(max_length=255, description="Repository name")
     description = fields.TextField(null=True, description="Repository description")
     html_url = fields.CharField(max_length=500, description="Repository URL")
+    relative_path = fields.CharField(max_length=500, description="The part of the repository's path excluding the domain")
 
     # Repository metadata
     default_branch = fields.CharField(

--- a/devdox/app/schemas/repo.py
+++ b/devdox/app/schemas/repo.py
@@ -71,6 +71,8 @@ class GitRepoResponse(BaseModel):
     repo_name: str = Field(..., description="Repository name")
     description: Optional[str] = Field(None, description="Repository description")
     html_url: str = Field(..., description="Repository URL")
+    relative_path: str = Field(..., description="The part of the repository's url excluding the domain")
+    
     default_branch: str = Field(..., description="Default branch name")
     forks_count: int = Field(..., description="Number of forks")
     stargazers_count: int = Field(..., description="Number of stars")
@@ -120,6 +122,7 @@ class GitLabRepoResponseTransformer:
             "created_at": project.created_at,
             "star_count": project.star_count,
             "http_url_to_repo": project.http_url_to_repo,
+            "path_with_namespace": project.path_with_namespace,
             "statistics": extracted_statistics,
         }
 
@@ -144,6 +147,7 @@ class GitLabRepoResponseTransformer:
             forks_count=dict_data.get("forks_count", 0),
             stargazers_count=dict_data.get("star_count", 0),
             html_url=dict_data.get("http_url_to_repo"),
+            relative_path=dict_data.get("path_with_namespace"),
             visibility=dict_data.get("visibility"),
             repo_created_at=dict_data.get("created_at"),
             size=cls.derive_storage_size(dict_data.get("statistics")) or 0,
@@ -162,6 +166,7 @@ class GitHubRepoResponseTransformer:
             "forks_count": repository.forks_count or 0,
             "size": repository.size or 0,
             "stargazers_count": repository.stargazers_count or 0,
+            "full_name": repository.full_name,
             "html_url": repository.html_url,
             "private": repository.private,
             "visibility": getattr(repository, "visibility", None),
@@ -189,6 +194,7 @@ class GitHubRepoResponseTransformer:
             default_branch=dict_data.get("default_branch", "main"),
             forks_count=dict_data.get("forks_count", 0),
             stargazers_count=dict_data.get("stargazers_count", 0),
+            relative_path=dict_data.get("full_name"),
             html_url=dict_data.get("html_url"),
             private=dict_data.get("private"),
             visibility=dict_data.get("visibility"),

--- a/devdox/app/services/repository_service.py
+++ b/devdox/app/services/repository_service.py
@@ -190,6 +190,7 @@ class RepoManipulationService:
                     repo_name=transformed_data.repo_name,
                     description=transformed_data.description,
                     html_url=transformed_data.html_url,
+                    relative_path=transformed_data.relative_path,
                     default_branch=transformed_data.default_branch,
                     forks_count=transformed_data.forks_count,
                     stargazers_count=transformed_data.stargazers_count,

--- a/devdox/tests/unit_test/app/schema/test_repo.py
+++ b/devdox/tests/unit_test/app/schema/test_repo.py
@@ -38,6 +38,7 @@ class TestGitLabRepoResponseTransformer:
             created_at=now,
             star_count=5,
             http_url_to_repo="http://example.com/repo",
+            path_with_namespace="repo",
             statistics={"storage_size": 2000},
         )
         result = GitLabRepoResponseTransformer.transform_project_to_dict(project)
@@ -56,6 +57,7 @@ class TestGitLabRepoResponseTransformer:
             "forks_count": 2,
             "star_count": 3,
             "http_url_to_repo": "http://example.com",
+            "path_with_namespace": "repo",
             "visibility": "internal",
             "created_at": datetime.utcnow(),
             "statistics": {"storage_size": 512},
@@ -92,6 +94,7 @@ class TestGitHubRepoResponseTransformer:
             forks_count=10,
             stargazers_count=100,
             html_url="http://github.com/repo",
+            full_name="repo",
             private=True,
             visibility="private",
             size=2048,
@@ -114,6 +117,7 @@ class TestGitHubRepoResponseTransformer:
             "forks_count": 5,
             "stargazers_count": 50,
             "html_url": "http://github.com/repo",
+            "full_name": "repo",
             "private": False,
             "visibility": "public",
             "size": 100,

--- a/devdox/tests/unit_test/app/services/test_repository_service.py
+++ b/devdox/tests/unit_test/app/services/test_repository_service.py
@@ -35,7 +35,7 @@ class StubFetcher:
             return self, lambda repo: GitRepoResponse(
                 id="r1", repo_name="test", description=None, html_url="url",
                 default_branch="main", forks_count=1, stargazers_count=2,
-                size=100, repo_created_at=None, private=True, visibility="private"
+                size=100, repo_created_at=None, private=True, visibility="private", relative_path="relative_url"
             )
         return None, None
 


### PR DESCRIPTION
# Description:
The `relative_path` is the part of the repository's path excluding the domain (like `github.com` or `gitlab.com`) and excluding the protocol (`https://` or `git@`).



# Summary:
- for github returns it as `full_name`
- for gitlab returns it as `path_with_namespace`
- Added `relative_path` to `Repo` model
- Added `relative_path` to `GitRepoResponse` DTO.
- Transforms from GitLab(Project | Dict) and GitHub(Repository | Dict) to the unified `GitRepoResponse` DTO now handles the `relative_path`
- Fixed the tests related to the changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new field to display the repository's relative path (excluding the domain) for both GitLab and GitHub repositories.
- **Bug Fixes**
  - Improved consistency in representing repository paths across different providers.
- **Tests**
  - Updated and extended tests to cover the new relative path field for repository data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->