### PR TITLE
test: Dapa 62 test get api v 1 git tokens write tests up to date with the changes

### DIFF
--- a/devdox/app/routes/git_tokens.py
+++ b/devdox/app/routes/git_tokens.py
@@ -17,7 +17,7 @@ from app.config import GitHosting
 from app.exceptions.exception_constants import SERVICE_UNAVAILABLE
 from models.git_label import GitLabel
 from models.user import User
-from app.schemas.basic import PaginationParams, RequiredPaginationParams
+from app.schemas.basic import PaginationParams
 from app.schemas.git_label import GetGitLabelsRequest, GitLabelBase, GitLabelCreate
 from app.services.git_tokens_service import GetGitLabelService
 from app.utils import constants, CurrentUser
@@ -130,9 +130,9 @@ async def handle_github(payload: GitLabelCreate, encrypted_token: str) -> JSONRe
     description="Retrieve a list of all git labels with masked token values",
 )
 async def get_git_labels(
+    user_claims: Annotated[UserClaims, Depends(get_authenticated_user)],
     request: Annotated[GetGitLabelsRequest, Depends()],
 	service: Annotated[GetGitLabelService, Depends(GetGitLabelService.with_dependency)],
-    current_user_id: AuthenticatedUserDTO = CurrentUser,
 ) -> JSONResponse:
     """
     Retrieves all stored git labels with masked token values for API response.
@@ -147,7 +147,7 @@ async def get_git_labels(
     """
     results = await service.get_git_labels_by_user(
         pagination=request.pagination,
-        user_claims=current_user_id,
+        user_claims=user_claims,
         git_hosting=request.git_hosting,
     )
 

--- a/devdox/app/services/git_tokens_service.py
+++ b/devdox/app/services/git_tokens_service.py
@@ -5,7 +5,7 @@ from fastapi import Depends
 from app.repositories.git_label_repository import TortoiseGitLabelStore
 from app.schemas.basic import RequiredPaginationParams
 from app.schemas.git_label import GitLabelResponse
-from app.utils.auth import AuthenticatedUserDTO
+from app.utils.auth import UserClaims
 
 
 def format_git_label_data(raw_git_labels):
@@ -41,11 +41,11 @@ class GetGitLabelService:
     ) -> "GetGitLabelService":
         return cls(label_store)
     
-    async def get_git_labels_by_user(self, pagination:RequiredPaginationParams, user_claims:AuthenticatedUserDTO, git_hosting:Optional[str]):
+    async def get_git_labels_by_user(self, pagination:RequiredPaginationParams, user_claims:UserClaims, git_hosting:Optional[str]):
 
         # Get total count
         total = await self.label_store.count_by_user_id(
-            user_id=user_claims.id,
+            user_id=user_claims.sub,
             git_hosting=git_hosting
         )
 
@@ -60,7 +60,7 @@ class GetGitLabelService:
         git_labels = await self.label_store.get_by_user_id(
             offset=pagination.offset,
             limit=pagination.limit,
-            user_id=user_claims.id,
+            user_id=user_claims.sub,
             git_hosting=git_hosting
         )
         

--- a/devdox/tests/unit_test/app/repository/test_git_label_repository.py
+++ b/devdox/tests/unit_test/app/repository/test_git_label_repository.py
@@ -1,0 +1,49 @@
+import pytest
+
+from app.exceptions.custom_exceptions import DevDoxAPIException
+from app.repositories.git_label_repository import TortoiseGitLabelStore
+
+
+@pytest.mark.asyncio
+class TestTortoiseGitLabelStore:
+
+    def setup_method(self):
+        self.store = TortoiseGitLabelStore()
+
+    async def test_raises_when_user_id_is_none(self):
+        with pytest.raises(DevDoxAPIException) as exc:
+            await self.store.get_by_user_id(offset=0, limit=10, user_id=None)
+        
+        expected_error = self.store.InternalExceptions.MISSING_USER_ID.value
+        assert exc.value.error_type == expected_error.get("error_type")
+
+    async def test_raises_when_user_id_missing_on_count(self):
+        with pytest.raises(DevDoxAPIException) as exc:
+            await self.store.count_by_user_id(user_id=None)
+        
+        expected_error = self.store.InternalExceptions.MISSING_USER_ID.value
+        assert exc.value.error_type == expected_error.get("error_type")
+
+    async def test_get_git_hosting_map_returns_empty_list_if_token_ids_empty(self):
+        result = await self.store.get_git_hosting_map_by_token_id(token_ids=[])
+        assert result == []
+
+    async def test_get_by_token_id_and_user_returns_none_if_token_id_blank(self):
+        result = await self.store.get_by_token_id_and_user(
+            token_id="", user_id="some-user"
+        )
+        assert result is None
+
+    async def test_get_by_token_id_and_user_returns_none_if_user_id_blank(self):
+        result = await self.store.get_by_token_id_and_user(
+            token_id="some-token", user_id=" "
+        )
+        assert result is None
+
+    async def test_get_by_token_id_and_user_returns_none_if_both_blank(self):
+        result = await self.store.get_by_token_id_and_user(token_id="", user_id=" ")
+        assert result is None
+
+    async def test_get_by_token_id_and_user_returns_none_if_both_none(self):
+        result = await self.store.get_by_token_id_and_user(token_id=None, user_id=None)
+        assert result is None

--- a/devdox/tests/unit_test/app/routes/test_git_tokens.py
+++ b/devdox/tests/unit_test/app/routes/test_git_tokens.py
@@ -1,626 +1,109 @@
-from unittest.mock import AsyncMock, MagicMock, patch
-from urllib.parse import quote
-
 import pytest
 from fastapi import status
+from fastapi.testclient import TestClient
+from app.main import app
+from app.utils.auth import UserClaims
+from app.services.git_tokens_service import GetGitLabelService
+from app.utils.auth import get_authenticated_user
+from app.exceptions.custom_exceptions import UnauthorizedAccess
+from tests.unit_test.test_doubles.app.repository.get_label_repository_doubles import FakeGitLabelStore, \
+    make_fake_git_label
+
+
+class TestGetGitLabelsRouter:
+    
+    route_url = "/api/v1/git_tokens/"
+    
+    @pytest.fixture
+    def t_client(self):
+        client = TestClient(app)
+        yield client
+    
+    @pytest.fixture
+    def per_t_client(self):
+        client = TestClient(app, raise_server_exceptions=False)
+        yield client
+    
+    @pytest.fixture
+    def override_auth_user(self):
+        async def _override():
+            return UserClaims(sub="user123")
+        app.dependency_overrides[get_authenticated_user] = _override
+        try:
+            yield
+        finally:
+            app.dependency_overrides.clear()
+
+    @pytest.fixture
+    def override_git_label_service_with_data(self):
+        def _override():
+            store = FakeGitLabelStore()
+            label = make_fake_git_label(user_id="user123", label="feature")
+            store.set_fake_data([label], total_count=1)
+            return GetGitLabelService(label_store=store)
+        app.dependency_overrides[GetGitLabelService.with_dependency] = _override
+        try:
+            yield
+        finally:
+            app.dependency_overrides.clear()
+
+    @pytest.fixture
+    def override_git_label_service_empty(self):
+        def _override():
+            store = FakeGitLabelStore()
+            store.set_fake_data([], total_count=0)
+            return GetGitLabelService(label_store=store)
+        app.dependency_overrides[GetGitLabelService.with_dependency] = _override
+        try:
+            yield
+        finally:
+            app.dependency_overrides.clear()
+
+    @pytest.fixture
+    def override_git_label_service_exception(self):
+        def _override():
+            store = FakeGitLabelStore()
+            store.set_exception("count_by_user_id", ValueError("Simulated error"))
+            return GetGitLabelService(label_store=store)
+        app.dependency_overrides[GetGitLabelService.with_dependency] = _override
+        try:
+            yield
+        finally:
+            app.dependency_overrides.clear()
+
+    @pytest.fixture
+    def override_auth_user_unauthorized(self):
+        async def _override():
+            raise UnauthorizedAccess("Invalid token")
+        app.dependency_overrides[get_authenticated_user] = _override
+        try:
+            yield
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_get_git_labels_success(self, t_client, override_auth_user, override_git_label_service_with_data):
+        response = t_client.get(f"{self.route_url}?limit=10&offset=0")
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["success"] is True
+        assert body["message"] == "Git labels retrieved successfully"
+        assert body["data"]["items"][0]["label"] == "feature"
+        assert body["data"]["total"] == 1
+
+    def test_get_git_labels_empty(self, t_client, override_auth_user, override_git_label_service_empty):
+        response = t_client.get(f"{self.route_url}?limit=10&offset=0")
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["data"]["items"] == []
+        assert body["data"]["total"] == 0
+
+    def test_get_git_labels_auth_failure(self, t_client, override_auth_user_unauthorized):
+        response = t_client.get(f"{self.route_url}?limit=10&offset=0")
 
-from app.exceptions.exception_constants import SERVICE_UNAVAILABLE
-from app.routes.git_tokens import mask_token
-from app.utils import constants
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-SAMPLE_USER_ID = "user-123"
-
-SAMPLE_SALT = 123
-
-
-@pytest.fixture
-def mock_user_model():
-    """Mock the User model with filter().first() pattern."""
-    # Patch where User is imported in the route file, not the model file
-    with patch("app.routes.git_tokens.User") as mock_user_class:
-        # Create mock user instance
-        mock_user_instance = MagicMock()
-        mock_user_instance.id = SAMPLE_USER_ID
-        mock_user_instance.encryption_salt = SAMPLE_SALT
-        mock_user_instance.save = AsyncMock()
-
-        # Setup the filter().first() chain
-        mock_filter = AsyncMock()
-        mock_filter.first = AsyncMock(return_value=mock_user_instance)
-        mock_user_class.filter = MagicMock(return_value=mock_filter)
-
-        yield mock_user_class
-
-
-class TestMaskToken:
-    """Test cases for token masking functionality."""
-
-    def test_mask_token_normal_length(self):
-        """Test masking for normal length token."""
-        token = "ghp_1234567890abcdef"
-        result = mask_token(token)
-        assert result == "ghp_************cdef"
-        assert len(result) == len(token)
-
-    @staticmethod
-    def __generate_test_data_with_ids_for_test_mask_token_short_token():
-        """Generates test data and custom IDs."""
-        character = "a"
-        max_characters = 9
-
-        for i in range(1, max_characters):
-            yield pytest.param(character * i, "*" * i, id=f"test_{i}_characters")
-
-    @pytest.mark.parametrize(
-        "input_value, expected_output",
-        __generate_test_data_with_ids_for_test_mask_token_short_token(),
-    )
-    def test_mask_token_short_token(self, input_value, expected_output):
-        """Test masking for short token (8 chars or less)."""
-        result = mask_token(input_value)
-        assert result == expected_output
-
-    @pytest.mark.parametrize(
-        "token",
-        [None, "", " "],
-        ids=["when token None", "when token empty string", "when token blank string"],
-    )
-    def test_mask_token_for_empty_token_forms(self, token):
-        """Test masking for invalid token."""
-        result = mask_token(token)
-        assert result == ""
-
-    def test_mask_token_exact_eight_chars(self):
-        """Test masking for a token of exactly 8 characters."""
-        token = "12345678"
-        result = mask_token(token)
-        assert result == "********"
-        assert len(result) == 8
-
-    def test_mask_token_nine_chars(self):
-        """Test masking for a token of exactly 9 characters."""
-        token = "123456789"
-        result = mask_token(token)
-        assert result == "1234*6789"
-        assert len(result) == 9
-
-
-class TestGetByLabelEndpoint:
-    """Test cases for GET /api/v1/git_tokens/{label} endpoint."""
-
-    @staticmethod
-    def get_url(raw_label: str) -> str:
-        label = quote(raw_label, safe="")
-        return f"/api/v1/git_tokens/{label}"
-
-    def test_get_git_label_by_label_success(
-        self, client, mock_encryption_helper, mock_authenticated_user
-    ):
-        """Test successful retrieval of git label by label."""
-
-        mock_labels = [
-            MagicMock(
-                id="1",
-                label="GitHub Production",
-                git_hosting="github",
-                token_value="encrypted_token",
-                username="testuser",
-                masked_token=mask_token("encrypted_token"),
-                created_at=MagicMock(
-                    isoformat=MagicMock(return_value="2024-01-01T10:00:00+00:00")
-                ),
-                updated_at=MagicMock(
-                    isoformat=MagicMock(return_value="2024-01-02T10:00:00+00:00")
-                ),
-            )
-        ]
-
-        with patch("app.routes.git_tokens.GitLabel") as mock_git_label:
-            mock_query = MagicMock()
-            mock_query.order_by.return_value = mock_query
-            mock_query.offset.return_value = mock_query
-            mock_query.limit.return_value = mock_query
-            mock_query.all = AsyncMock(return_value=mock_labels)
-
-            mock_git_label.filter.return_value = mock_query
-
-            response = client.get(TestGetByLabelEndpoint.get_url("GitHub Production"))
-
-            assert response.status_code == status.HTTP_200_OK
-            data = response.json()
-            assert data["success"] is True
-            assert len(data["data"]["items"]) == 1
-
-            label = data["data"]["items"][0]
-            assert label["id"] == "1"
-            assert label["label"] == "GitHub Production"
-            assert label["git_hosting"] == "github"
-
-    def test_get_git_label_by_nonexistent_label(self, client, mock_authenticated_user):
-        """Test getting git label with label that doesn't exist."""
-
-        with patch("app.routes.git_tokens.GitLabel") as mock_git_label:
-            mock_query = MagicMock()
-            mock_query.order_by.return_value = mock_query
-            mock_query.offset.return_value = mock_query
-            mock_query.limit.return_value = mock_query
-            mock_query.all = AsyncMock(return_value=[])
-
-            mock_git_label.filter.return_value = mock_query
-
-            response = client.get(TestGetByLabelEndpoint.get_url("NonExistentLabel"))
-
-            assert response.status_code == status.HTTP_200_OK
-            data = response.json()
-            assert data["success"] is True
-            assert data["data"]["items"] == []
-
-    def test_get_git_label_by_label_database_error(
-        self, client, mock_authenticated_user
-    ):
-        """Test error handling when database query fails."""
-
-        with patch("app.routes.git_tokens.GitLabel") as mock_git_label:
-            mock_git_label.filter.side_effect = Exception("Database error")
-
-            response = client.get(TestGetByLabelEndpoint.get_url("SomeLabel"))
-
-            assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
-            data = response.json()
-            assert data["success"] is False
-            assert "Service temporarily unavailable" in data["message"]
-
-
-# Constants for mock data
-INVALID_TOKENS = [
-    ("", ""),  # Empty token
-    (None, ""),  # None token
-    ("short", "*****"),  # Very short token
-]
-
-ENCRYPTION_EXCEPTION = Exception("Decryption failed")
-
-
-class TestGetByLabelEdgeCases:
-    """Edge test cases for GET /api/v1/git_tokens/{label} endpoint."""
-
-    @staticmethod
-    def get_url(raw_label: str) -> str:
-        label = quote(raw_label, safe="")
-        return f"/api/v1/git_tokens/{label}"
-
-    def test_get_git_label_with_missing_token(self, client, mock_authenticated_user):
-        """Should return masked empty string for labels with missing token_value."""
-        label = "GitHub Missing Token"
-
-        mock_labels = [
-            MagicMock(
-                id="1",
-                label=label,
-                git_hosting="github",
-                token_value=None,
-                masked_token="",
-                username="devuser",
-                created_at=MagicMock(
-                    isoformat=MagicMock(return_value="2025-01-01T10:00:00Z")
-                ),
-                updated_at=MagicMock(
-                    isoformat=MagicMock(return_value="2025-01-02T10:00:00Z")
-                ),
-            )
-        ]
-
-        with (
-            patch("app.routes.git_tokens.GitLabel") as mock_git_label,
-            patch("app.routes.git_tokens.EncryptionHelper.decrypt", return_value=""),
-        ):
-            mock_query = MagicMock()
-            mock_query.order_by.return_value = mock_query
-            mock_query.offset.return_value = mock_query
-            mock_query.limit.return_value = mock_query
-            mock_query.all = AsyncMock(return_value=mock_labels)
-            mock_git_label.filter.return_value = mock_query
-
-            response = client.get(self.get_url(label))
-            assert response.status_code == status.HTTP_200_OK
-            data = response.json()
-            assert data["success"] is True
-            assert data["data"]["items"][0]["masked_token"] == ""
-
-    def test_get_git_label_with_non_ascii_label(self, client, mock_authenticated_user):
-        """Should handle non-ASCII labels (e.g., emojis, Arabic, Japanese) gracefully."""
-        non_ascii_label = "🚀🔥中文ラベル"
-        with patch("app.routes.git_tokens.GitLabel") as mock_git_label:
-            mock_query = MagicMock()
-            mock_query.order_by.return_value = mock_query
-            mock_query.offset.return_value = mock_query
-            mock_query.limit.return_value = mock_query
-            mock_query.all = AsyncMock(return_value=[])
-            mock_git_label.filter.return_value = mock_query
-
-            response = client.get(self.get_url(non_ascii_label))
-            assert response.status_code == status.HTTP_200_OK
-            assert response.json()["data"]["items"] == []
-
-    def test_get_git_label_extreme_pagination(self, client, mock_authenticated_user):
-        """Should correctly apply very large pagination offset."""
-        url = self.get_url("ValidLabel") + "?limit=10&offset=10000"
-        with patch("app.routes.git_tokens.GitLabel") as mock_git_label:
-            mock_query = MagicMock()
-            mock_query.order_by.return_value = mock_query
-            mock_query.offset.return_value = mock_query
-            mock_query.limit.return_value = mock_query
-            mock_query.all = AsyncMock(return_value=[])
-            mock_git_label.filter.return_value = mock_query
-
-            response = client.get(url)
-            assert response.status_code == status.HTTP_200_OK
-            assert response.json()["data"]["items"] == []
-
-    def test_get_git_label_filter_applies_user_id_correctly(
-        self, client, mock_authenticated_user
-    ):
-        """Should filter GitLabel using user_id from auth DTO."""
-        label = "UniqueFilterTest"
-        with patch("app.routes.git_tokens.GitLabel") as mock_git_label:
-            mock_query = MagicMock()
-            mock_query.order_by.return_value = mock_query
-            mock_query.offset.return_value = mock_query
-            mock_query.limit.return_value = mock_query
-            mock_query.all = AsyncMock(return_value=[])
-            mock_git_label.filter.return_value = mock_query
-
-            client.get(self.get_url(label))
-
-            mock_git_label.filter.assert_called_once_with(
-                user_id="user_abc123", label=label
-            )
-
-
-class TestAddGitTokenEndpoint:
-    """Test cases for POST /api/v1/git_tokens/ endpoint."""
-
-    @staticmethod
-    def get_url() -> str:
-        return f"/api/v1/git_tokens/"
-
-    def test_add_github_token_success(
-        self,
-        client,
-        token_payload_github,
-        mock_user_model,
-        mock_encryption_helper,
-        mock_authenticated_user,
-    ):
-        """Test successful creation of a GitHub token."""
-        with patch("app.routes.git_tokens.GitHubManager") as mock_github_manager:
-            # Setup successful GitHub manager
-            mock_instance = MagicMock()
-            mock_instance.get_user.return_value = {"login": "testuser"}
-            mock_github_manager.return_value = mock_instance
-
-            with patch("app.routes.git_tokens.GitLabel") as mock_git_label:
-                # Setup successful GitLabel creation
-                mock_created_label = MagicMock()
-                mock_created_label.id = "999"
-                mock_git_label.create = AsyncMock(return_value=mock_created_label)
-
-                response = client.post(
-                    TestAddGitTokenEndpoint.get_url(), json=token_payload_github
-                )
-
-                assert response.status_code == status.HTTP_200_OK
-                data = response.json()
-                assert data["success"] is True
-                assert data["data"]["id"] == "999"
-
-                # Verify GitLabel.create was called
-                mock_git_label.create.assert_called_once()
-
-    def test_add_gitlab_token_success(
-        self,
-        client,
-        mock_user_model,
-        token_payload_gitlab,
-        mock_encryption_helper,
-        mock_authenticated_user,
-    ):
-        """Test successful creation of a GitLab token."""
-        with patch("app.routes.git_tokens.GitLabManager") as mock_gitlab_manager:
-            # Setup successful GitLab manager
-            mock_instance = MagicMock()
-            mock_instance.auth_status = True
-            mock_instance.get_user.return_value = {"username": "testuser"}
-            mock_gitlab_manager.return_value = mock_instance
-
-            with patch("app.routes.git_tokens.GitLabel") as mock_git_label:
-                mock_created_label = MagicMock()
-                mock_created_label.id = "999"
-                mock_git_label.create = AsyncMock(return_value=mock_created_label)
-
-                response = client.post(
-                    TestAddGitTokenEndpoint.get_url(), json=token_payload_gitlab
-                )
-
-                assert response.status_code == status.HTTP_200_OK
-                data = response.json()
-                assert data["success"] is True
-                assert data["data"]["id"] == "999"
-
-    def test_add_github_token_authentication_failure(
-        self,
-        client,
-        mock_user_model,
-        token_payload_github,
-        mock_encryption_helper,
-        mock_authenticated_user,
-    ):
-        """Test GitHub token creation with authentication failure."""
-        with patch("app.routes.git_tokens.GitHubManager") as mock_github_manager:
-            mock_instance = MagicMock()
-            mock_instance.get_user.return_value = None
-            mock_github_manager.return_value = mock_instance
-
-            response = client.post(
-                TestAddGitTokenEndpoint.get_url(), json=token_payload_github
-            )
-
-            assert response.status_code == status.HTTP_400_BAD_REQUEST
-            data = response.json()
-            assert data["success"] is False
-            assert "Failed to authenticate with GitHub" in data["message"]
-
-    def test_add_gitlab_token_authentication_failure(
-        self,
-        client,
-        mock_user_model,
-        token_payload_gitlab,
-        mock_encryption_helper,
-        mock_authenticated_user,
-    ):
-        """Test GitLab token creation with authentication failure."""
-        with patch("app.routes.git_tokens.GitLabManager") as mock_gitlab_manager:
-            # Setup failed GitLab manager
-            mock_instance = MagicMock()
-            mock_instance.auth_status = False
-            mock_gitlab_manager.return_value = mock_instance
-
-            response = client.post(
-                TestAddGitTokenEndpoint.get_url(), json=token_payload_gitlab
-            )
-
-            assert response.status_code == status.HTTP_400_BAD_REQUEST
-            data = response.json()
-            assert data["success"] is False
-            assert "Failed to authenticate with GitLab" in data["message"]
-
-    def test_add_gitlab_token_user_fetch_failure(
-        self, client, mock_user_model, mock_encryption_helper, mock_authenticated_user
-    ):
-        """Test GitLab token creation with user fetch failure."""
-        with patch("app.routes.git_tokens.GitLabManager") as mock_gitlab_manager:
-            # Mock GitLab auth success but user fetch failure
-            mock_instance = MagicMock()
-            mock_instance.auth_status = True
-            mock_instance.get_user.return_value = None
-            mock_gitlab_manager.return_value = mock_instance
-
-            payload = {
-                "label": "Test GitLab Token",
-                "git_hosting": "gitlab",
-                "token_value": "glpat-1234567890abcdef",
-            }
-
-            response = client.post(TestAddGitTokenEndpoint.get_url(), json=payload)
-
-            assert response.status_code == status.HTTP_400_BAD_REQUEST
-            data = response.json()
-            assert data["success"] is False
-            assert constants.GITLAB_USER_RETRIEVE_FAILED in data["message"]
-
-            # Verify user data was attempted to be fetched
-            mock_gitlab_manager.return_value.get_user.assert_called_once()
-
-    def test_add_token_unsupported_provider(
-        self, client, mock_user_model, mock_encryption_helper, mock_authenticated_user
-    ):
-        """Test creation with unsupported git hosting provider."""
-        payload = {
-            "label": "Test Token",
-            "git_hosting": "bitbucket",  # Unsupported provider
-            "token_value": "token123456",
-        }
-
-        response = client.post(TestAddGitTokenEndpoint.get_url(), json=payload)
-
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-        data = response.json()
-        assert data["success"] is False
-        assert "Unsupported git hosting provider" in data["message"]
-
-    def test_add_token_empty_token(
-        self, client, mock_encryption_helper, mock_authenticated_user
-    ):
-        """Test creation with empty token."""
-        payload = {
-            "label": "Test GitHub Token",
-            "git_hosting": "github",
-            "token_value": "",  # Empty token
-        }
-
-        response = client.post(TestAddGitTokenEndpoint.get_url(), json=payload)
-
-        assert response.status_code in [
-            status.HTTP_422_UNPROCESSABLE_ENTITY,
-            status.HTTP_400_BAD_REQUEST,
-        ]
-
-    def test_user_id_override_security(
-        self, client, mock_user_model, mock_encryption_helper, mock_authenticated_user
-    ):
-        """Test that user_id is overridden with authenticated user for security."""
-        with patch("app.routes.git_tokens.GitHubManager") as mock_github_manager:
-            mock_instance = MagicMock()
-            mock_instance.get_user.return_value = {"login": "testuser"}
-            mock_github_manager.return_value = mock_instance
-
-            with patch("app.routes.git_tokens.GitLabel") as mock_git_label:
-                mock_created_label = MagicMock()
-                mock_created_label.id = "999"
-                mock_git_label.create = AsyncMock(return_value=mock_created_label)
-
-                payload = {
-                    "label": "Test GitHub Token",
-                    "git_hosting": "github",
-                    "token_value": "ghp_1234567890abcdef",
-                    "user_id": "malicious-user-id",  # This should be overridden
-                }
-
-                response = client.post(TestAddGitTokenEndpoint.get_url(), json=payload)
-
-                assert response.status_code == status.HTTP_200_OK
-
-                # Verify that GitLabel.create was called with the authenticated user ID, not the provided one
-                call_args = mock_git_label.create.call_args
-                assert call_args.kwargs["user_id"] == mock_authenticated_user.id
-
-    def test_add_gitlab_auth_status_false(
-        self, client, mock_user_model, mock_encryption_helper, mock_authenticated_user
-    ):
-        """Test GitLab token creation auth status failure."""
-        with patch("app.routes.git_tokens.GitLabManager") as mock_gitlab_manager:
-            # Mock GitLab auth success but user fetch failure
-            mock_instance = MagicMock()
-            mock_instance.auth_status = False
-            mock_instance.get_user.return_value = None
-            mock_gitlab_manager.return_value = mock_instance
-
-            payload = {
-                "label": "Test GitLab Token",
-                "git_hosting": "gitlab",
-                "token_value": "glpat-1234567890abcdef",
-            }
-
-            response = client.post(TestAddGitTokenEndpoint.get_url(), json=payload)
-
-            assert response.status_code == status.HTTP_400_BAD_REQUEST
-            data = response.json()
-            assert data["success"] is False
-            assert constants.GITLAB_AUTH_FAILED in data["message"]
-
-    async def test_add_git_token_exception(
-        self, client, mock_user_model, mock_encryption_helper, mock_authenticated_user
-    ):
-        # Simulate exception inside encrypt_for_user
-        mock_encryption_helper.side_effect = Exception("Simulated failure")
-
-        payload = {
-            "label": "My Git Token",
-            "git_hosting": "github",
-            "token_value": "some-token",
-        }
-
-        # Use a mock authenticated user header or dependency override
-        headers = {"Authorization": "Bearer dummy_token"}  # Adjust to your auth method
-        response = client.post(TestAddGitTokenEndpoint.get_url(), json=payload)
-
-        assert response.status_code == 500
-        assert response.json()["message"] == SERVICE_UNAVAILABLE
-
-
-class TestDeleteGitLabelEndpoint:
-    """Test cases for DELETE /api/v1/git_tokens/{git_label_id} endpoint."""
-
-    @staticmethod
-    def get_url(git_label_id: str) -> str:
-        return f"/api/v1/git_tokens/{git_label_id}"
-
-    def test_delete_git_label_success(
-        self, client, sample_token_id, mock_authenticated_user
-    ):
-        """Test successful git label deletion."""
-        with patch("app.routes.git_tokens.GitLabel") as mock_git_label:
-            mock_label = MagicMock()
-            mock_label.delete = AsyncMock()
-            mock_git_label.filter.return_value.first = AsyncMock(
-                return_value=mock_label
-            )
-
-            response = client.delete(
-                TestDeleteGitLabelEndpoint.get_url(sample_token_id)
-            )
-
-            assert response.status_code == status.HTTP_200_OK
-            data = response.json()
-            assert data["success"] is True
-            assert "Token deleted successfully" in data["message"]
-
-            mock_label.delete.assert_called_once()
-
-    def test_delete_git_label_not_found(
-        self, client, sample_token_id, mock_authenticated_user
-    ):
-        """Test deletion when git label doesn't exist."""
-        with patch("app.routes.git_tokens.GitLabel") as mock_git_label:
-            mock_git_label.filter.return_value.first = AsyncMock(return_value=None)
-
-            response = client.delete(
-                TestDeleteGitLabelEndpoint.get_url(sample_token_id)
-            )
-
-            assert response.status_code == status.HTTP_404_NOT_FOUND
-            data = response.json()
-            assert data["success"] is False
-            assert "Token not found" in data["message"]
-
-    def test_delete_git_label_invalid_uuid(self, client, mock_authenticated_user):
-        """Test deletion with invalid UUID format."""
-
-        response = client.delete(TestDeleteGitLabelEndpoint.get_url("invalid-uuid"))
-
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        data = response.json()
-        assert data["success"] is False
-        assert "Invalid UUID format" in data["message"]
-
-    def test_delete_token_database_error_on_get(
-        self, client, sample_token_id, mock_authenticated_user
-    ):
-        """Test handling of database error during get operation"""
-        with patch("app.routes.git_tokens.GitLabel") as mock_git_label:
-            mock_git_label.get = AsyncMock(
-                side_effect=Exception("Database connection failed")
-            )
-
-            response = client.delete(
-                TestDeleteGitLabelEndpoint.get_url(sample_token_id)
-            )
-
-            assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
-            data = response.json()
-            assert data["success"] is False
-            assert "Service temporarily unavailable" in data["message"]
-
-    @pytest.mark.parametrize(
-        "token_id",
-        [
-            "550e8400-e29b-41d4-a716-446655440000",  # Valid UUID
-            "123e4567-e89b-12d3-a456-426614174000",  # Another valid UUID
-        ],
-    )
-    def test_delete_token_valid_uuid_formats(
-        self, client, token_id, mock_authenticated_user
-    ):
-        """Test deletion with valid UUID formats"""
-        with patch("app.routes.git_tokens.GitLabel") as mock_git_label:
-            mock_label = MagicMock()
-            mock_label.delete = AsyncMock()
-            mock_git_label.filter.return_value.first = AsyncMock(
-                return_value=mock_label
-            )
-
-            response = client.delete(TestDeleteGitLabelEndpoint.get_url(token_id))
-
-            assert response.status_code == status.HTTP_200_OK
-            data = response.json()
-            assert data["success"] is True
+    def test_get_git_labels_service_raises(self, per_t_client, override_auth_user, override_git_label_service_exception):
+        response = per_t_client.get(f"{self.route_url}?limit=10&offset=0")
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE

--- a/devdox/tests/unit_test/app/services/test_git_tokens_service.py
+++ b/devdox/tests/unit_test/app/services/test_git_tokens_service.py
@@ -1,0 +1,75 @@
+import pytest
+
+from app.schemas.basic import RequiredPaginationParams
+from app.services.git_tokens_service import GetGitLabelService
+from app.utils.auth import UserClaims
+from tests.unit_test.test_doubles.app.repository.get_label_repository_doubles import FakeGitLabelStore, \
+	make_fake_git_label
+
+
+@pytest.mark.asyncio
+class TestGetGitLabelService:
+    def setup_method(self):
+        self.fake_store = FakeGitLabelStore()
+        self.service = GetGitLabelService(label_store=self.fake_store)
+        self.user_claims = UserClaims(sub="user123")
+
+    async def test_returns_empty_if_store_count_is_zero(self):
+        self.fake_store.set_fake_data([], total_count=0)
+        pagination = RequiredPaginationParams(limit=10, offset=0)
+
+        result = await self.service.get_git_labels_by_user(
+            pagination=pagination,
+            user_claims=self.user_claims,
+            git_hosting=None,
+        )
+
+        assert result == {
+            "items": [],
+            "total": 0,
+            "page": 1,
+            "size": 10,
+        }
+        assert ("count_by_user_id", "user123", None) in self.fake_store.received_calls
+
+    async def test_returns_formatted_git_labels(self):
+        fake_label = make_fake_git_label(user_id="user123", label="bugfix")
+        self.fake_store.set_fake_data([fake_label], total_count=1)
+        pagination = RequiredPaginationParams(limit=10, offset=0)
+
+        result = await self.service.get_git_labels_by_user(
+            pagination=pagination,
+            user_claims=self.user_claims,
+            git_hosting="github",
+        )
+
+        assert result["total"] == 1
+        assert result["items"][0]["label"] == "bugfix"
+        assert result["items"][0]["masked_token"] == "****1234"
+        assert ("count_by_user_id", "user123", "github") in self.fake_store.received_calls
+        assert ("get_by_user_id", 0, 10, "user123", "github") in self.fake_store.received_calls
+
+    async def test_correct_page_calculation(self):
+        self.fake_store.set_fake_data([], total_count=0)
+        pagination = RequiredPaginationParams(limit=20, offset=40)
+
+        result = await self.service.get_git_labels_by_user(
+            pagination=pagination,
+            user_claims=self.user_claims,
+            git_hosting=None,
+        )
+
+        assert result["page"] == 3  # (offset // limit) + 1
+    
+    async def test_bubbles_up_store_exception(self):
+        self.fake_store.set_exception("count_by_user_id", ValueError("Boom"))
+        pagination = RequiredPaginationParams(limit=10, offset=0)
+
+        with pytest.raises(ValueError) as exc:
+            await self.service.get_git_labels_by_user(
+                pagination=pagination,
+                user_claims=self.user_claims,
+                git_hosting=None,
+            )
+
+        assert str(exc.value) == "Boom"

--- a/devdox/tests/unit_test/app/services/test_git_tokens_service.py
+++ b/devdox/tests/unit_test/app/services/test_git_tokens_service.py
@@ -48,18 +48,6 @@ class TestGetGitLabelService:
         assert result["items"][0]["masked_token"] == "****1234"
         assert ("count_by_user_id", "user123", "github") in self.fake_store.received_calls
         assert ("get_by_user_id", 0, 10, "user123", "github") in self.fake_store.received_calls
-
-    async def test_correct_page_calculation(self):
-        self.fake_store.set_fake_data([], total_count=0)
-        pagination = RequiredPaginationParams(limit=20, offset=40)
-
-        result = await self.service.get_git_labels_by_user(
-            pagination=pagination,
-            user_claims=self.user_claims,
-            git_hosting=None,
-        )
-
-        assert result["page"] == 3  # (offset // limit) + 1
     
     async def test_bubbles_up_store_exception(self):
         self.fake_store.set_exception("count_by_user_id", ValueError("Boom"))

--- a/devdox/tests/unit_test/test_doubles/app/repository/get_label_repository_doubles.py
+++ b/devdox/tests/unit_test/test_doubles/app/repository/get_label_repository_doubles.py
@@ -1,0 +1,59 @@
+import datetime
+from typing import List, Optional
+from uuid import uuid4
+
+from models import GitLabel
+
+
+class FakeGitLabelStore:
+    def __init__(self):
+        self.git_labels: List[GitLabel] = []
+        self.total_count = 0
+        self.received_calls = []  # for optional spy behavior
+        self.exceptions = {}  # method_name -> exception to raise
+
+    def set_fake_data(self, git_labels: List[GitLabel], total_count: Optional[int] = None):
+        self.git_labels = git_labels
+        self.total_count = total_count if total_count is not None else len(git_labels)
+
+    def set_exception(self, method_name: str, exception: Exception):
+        self.exceptions[method_name] = exception
+
+    async def get_by_user_id(self, offset, limit, user_id, git_hosting=None):
+        if "get_by_user_id" in self.exceptions:
+            raise self.exceptions["get_by_user_id"]
+        self.received_calls.append(("get_by_user_id", offset, limit, user_id, git_hosting))
+        return self.git_labels
+
+    async def count_by_user_id(self, user_id, git_hosting=None):
+        if "count_by_user_id" in self.exceptions:
+            raise self.exceptions["count_by_user_id"]
+        self.received_calls.append(("count_by_user_id", user_id, git_hosting))
+        return self.total_count
+
+    async def get_by_token_id_and_user(self, token_id, user_id):
+        if "get_by_token_id_and_user" in self.exceptions:
+            raise self.exceptions["get_by_token_id_and_user"]
+        self.received_calls.append(("get_by_token_id_and_user", token_id, user_id))
+        return next((lbl for lbl in self.git_labels if str(lbl.id) == token_id and lbl.user_id == user_id), None)
+
+    async def get_git_hosting_map_by_token_id(self, token_ids):
+        if "get_git_hosting_map_by_token_id" in self.exceptions:
+            raise self.exceptions["get_git_hosting_map_by_token_id"]
+        self.received_calls.append(("get_git_hosting_map_by_token_id", token_ids))
+        return [{"id": str(lbl.id), "git_hosting": lbl.git_hosting} for lbl in self.git_labels if str(lbl.id) in token_ids]
+
+
+def make_fake_git_label(**overrides) -> GitLabel:
+    now = datetime.datetime.now()
+    return GitLabel(
+        id=overrides.get("id", uuid4()),
+        user_id=overrides.get("user_id", "fake-user"),
+        label=overrides.get("label", "fake-label"),
+        git_hosting=overrides.get("git_hosting", "github"),
+        username=overrides.get("username", "fakeuser"),
+        token_value=overrides.get("token_value", "real-token"),
+        masked_token=overrides.get("masked_token", "****1234"),
+        created_at=overrides.get("created_at", now),
+        updated_at=overrides.get("updated_at", now),
+    )


### PR DESCRIPTION
Introduced several tests that are up to date with the changes that were done.

Depends on:
- https://github.com/montymobile1/devdox-ai-portal-api/pull/55
- https://github.com/montymobile1/devdox-ai-portal-api/pull/56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a dedicated service for retrieving and formatting user Git label data with pagination and optional filtering.
  - Added a request schema to handle pagination and filtering for Git label queries.

- **Refactor**
  - Simplified the GET `/api/v1/git_tokens/` endpoint by delegating business logic to a service layer and streamlining the route handler.

- **Bug Fixes**
  - Improved error handling and consistency when querying Git label data by user ID.

- **Tests**
  - Deprecated outdated tests for the previous Git label endpoint.
  - Added comprehensive unit and integration tests for the new service, route, and repository logic, including test doubles for repository interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->