### PR TITLE
refactor: Added the servicer/router layer separation

### DIFF
--- a/devdox/app/repositories/git_label_repository.py
+++ b/devdox/app/repositories/git_label_repository.py
@@ -1,3 +1,4 @@
+import uuid
 from abc import abstractmethod
 from enum import Enum
 from typing import Any, Collection, Dict, List, Optional, Protocol, Union
@@ -34,7 +35,9 @@ class ILabelStore(Protocol):
     
     @abstractmethod
     async def create_new(self, label_model: GitLabelDBCreateDTO) -> Any: ...
-
+    
+    @abstractmethod
+    async def delete_by_id_and_user_id(self, label_id:uuid.UUID, user_id:str) -> GitLabel | None: ...
 
 def internal_error(log_message:str, error_type:str, **kwargs):
     return DevDoxAPIException(
@@ -47,12 +50,24 @@ def internal_error(log_message:str, error_type:str, **kwargs):
 
 class TortoiseGitLabelStore(ILabelStore):
 
+    def __init__(self):
+        """
+        Have to add this as an empty __init__ to override it, because when using it with Depends(),
+        FastAPI dependency mechanism will automatically assume its
+        ```
+        def __init__(self, *args, **kwargs):
+            pass
+        ```
+        Causing unneeded behavior.
+        """
+        pass
+
     class InternalExceptions(Enum):
         MISSING_USER_ID = {
             "error_type": MISSING_USER_ID_TITLE,
             "log_message": MISSING_USER_ID_LOG_MESSAGE
         }
-        
+
         MISSING_LABEL = {
             "error_type": MISSING_LABEL_ID_TITLE,
             "log_message": MISSING_LABEL_LOG_MESSAGE
@@ -103,20 +118,40 @@ class TortoiseGitLabelStore(ILabelStore):
 
         if not user_id:
             raise internal_error(**self.InternalExceptions.MISSING_USER_ID.value)
-        
+
         if not label or not label.strip():
             raise internal_error(**self.InternalExceptions.MISSING_LABEL.value)
-        
+
         query = GitLabel.filter(user_id=user_id, label=label)
-        
+
         git_labels = (
             await query
             .order_by("-created_at")
             .offset(offset).limit(limit)
             .all()
         )
-        
+
         return git_labels
 
     async def create_new(self, label_model: GitLabelDBCreateDTO) -> GitLabel:
         return await GitLabel.create(**label_model.model_dump())
+
+    async def delete_by_id_and_user_id(self, label_id:uuid, user_id:str) -> GitLabel | None:
+        """
+        .delete returns 0 when No record is found or total number of records deleted.
+        """
+        if not label_id or not user_id or not user_id.strip():
+            return None
+
+        retrieved_git_label = await GitLabel.filter(id=label_id, user_id=user_id).first()
+        
+        if not retrieved_git_label:
+            return None
+        
+        deleted_count = await retrieved_git_label.delete()
+        
+        if deleted_count == 0:
+            return None
+        
+        return retrieved_git_label
+        

--- a/devdox/app/repositories/repo_repository.py
+++ b/devdox/app/repositories/repo_repository.py
@@ -14,7 +14,19 @@ class IRepoStore(Protocol):
     async def create_new_repo(self, repo_model: Any) -> Any: ...
 
 class TortoiseRepoStore(IRepoStore):
-
+    
+    def __init__(self):
+        """
+        Have to add this as an empty __init__ to override it, because when using it with Depends(),
+        FastAPI dependency mechanism will automatically assume its
+        ```
+        def __init__(self, *args, **kwargs):
+            pass
+        ```
+        Causing unneeded behavior.
+        """
+        pass
+    
     async def get_all_by_user(
         self, user_id: str, offset: int, limit: int
     ) -> List[Repo]:

--- a/devdox/app/repositories/user_repository.py
+++ b/devdox/app/repositories/user_repository.py
@@ -10,7 +10,19 @@ class IUserStore(Protocol):
 
 
 class TortoiseUserStore(IUserStore):
-
+    
+    def __init__(self):
+        """
+        Have to add this as an empty __init__ to override it, because when using it with Depends(),
+        FastAPI dependency mechanism will automatically assume its
+        ```
+        def __init__(self, *args, **kwargs):
+            pass
+        ```
+        Causing unneeded behavior.
+        """
+        pass
+    
     async def get_by_user_id(self, user_id: str) -> User | None:
         if not user_id or not user_id.strip():
             return None

--- a/devdox/app/schemas/git_label.py
+++ b/devdox/app/schemas/git_label.py
@@ -91,6 +91,13 @@ class AddGitTokenRequest:
     ):
         self.payload = payload
 
+class DeleteGitTokenRequest:
+    def __init__(
+        self,
+        git_label_id: uuid.UUID = Path(..., description="The git label id")
+    ):
+        self.git_label_id = git_label_id
+
 
 class GitLabelDBCreateDTO(BaseModel):
     label:str = Field(..., description=LABEL_FIELD_DESCRIPTION)

--- a/devdox/app/services/git_tokens_service.py
+++ b/devdox/app/services/git_tokens_service.py
@@ -9,7 +9,8 @@ from app.exceptions.custom_exceptions import BadRequest, ResourceNotFound
 from app.exceptions.exception_constants import (
     GENERIC_ALREADY_EXIST,
     TOKEN_MISSING,
-    TOKEN_NOT_FOUND, USER_RESOURCE_NOT_FOUND,
+    TOKEN_NOT_FOUND,
+    USER_RESOURCE_NOT_FOUND,
 )
 from app.repositories.git_label_repository import TortoiseGitLabelStore
 from app.repositories.user_repository import TortoiseUserStore
@@ -26,53 +27,57 @@ from app.utils.repo_fetcher import RepoFetcher
 
 logger = logging.getLogger(__name__)
 
+
 def format_git_label_data(raw_git_labels):
     formatted_data = []
     for git_label in raw_git_labels:
-        
+
         formatted_data.append(
             GitLabelResponse(
-                id= git_label.id,
+                id=git_label.id,
                 user_id=git_label.user_id,
-                label= git_label.label,
-                git_hosting= git_label.git_hosting,
-                masked_token= git_label.masked_token,
-                username= git_label.username,
-                created_at= git_label.created_at.isoformat(),
-                updated_at= git_label.updated_at.isoformat(),
+                label=git_label.label,
+                git_hosting=git_label.git_hosting,
+                masked_token=git_label.masked_token,
+                username=git_label.username,
+                created_at=git_label.created_at.isoformat(),
+                updated_at=git_label.updated_at.isoformat(),
                 token_value=git_label.token_value,
             ).model_dump(exclude={"token_value", "user_id"})
         )
-    
+
     return formatted_data
 
 
 class GetGitLabelService:
 
-    def __init__(
-            self,
-            label_store: TortoiseGitLabelStore
-    ):
+    def __init__(self, label_store: TortoiseGitLabelStore):
         self.label_store = label_store
-    
+
     @classmethod
-    def with_dependency(cls, label_store: Annotated[TortoiseGitLabelStore, Depends()],
+    def with_dependency(
+        cls,
+        label_store: Annotated[TortoiseGitLabelStore, Depends()],
     ) -> "GetGitLabelService":
         return cls(label_store)
-    
-    async def get_git_labels_by_user(self, pagination:RequiredPaginationParams, user_claims:UserClaims, git_hosting:Optional[str]):
+
+    async def get_git_labels_by_user(
+        self,
+        pagination: RequiredPaginationParams,
+        user_claims: UserClaims,
+        git_hosting: Optional[str],
+    ):
 
         # Get total count
         total = await self.label_store.count_by_user_id(
-            user_id=user_claims.sub,
-            git_hosting=git_hosting
+            user_id=user_claims.sub, git_hosting=git_hosting
         )
 
         if total == 0:
             return {
                 "items": [],
                 "total": total,
-                "page": pagination.offset  + 1,
+                "page": pagination.offset + 1,
                 "size": pagination.limit,
             }
 
@@ -80,7 +85,7 @@ class GetGitLabelService:
             offset=pagination.offset,
             limit=pagination.limit,
             user_id=user_claims.sub,
-            git_hosting=git_hosting
+            git_hosting=git_hosting,
         )
 
         # Format response data with masked tokens
@@ -89,22 +94,25 @@ class GetGitLabelService:
         return {
             "items": formatted_data,
             "total": total,
-            "page": pagination.offset  + 1,
+            "page": pagination.offset + 1,
             "size": pagination.limit,
         }
 
-    async def get_git_labels_by_label(self, pagination: PaginationParams, user_claims: UserClaims, label: str):
+    async def get_git_labels_by_label(
+        self, pagination: PaginationParams, user_claims: UserClaims, label: str
+    ):
 
         git_labels = await self.label_store.get_by_user_id_and_label(
             offset=pagination.offset,
             limit=pagination.limit,
             user_id=user_claims.sub,
-            label=label
+            label=label,
         )
 
         formatted_data = format_git_label_data(git_labels)
 
         return formatted_data
+
 
 def mask_token(token: str) -> str:
     """
@@ -127,10 +135,15 @@ def mask_token(token: str) -> str:
 
     return f"{prefix}{middle_mask}{suffix}"
 
+
 class PostGitLabelService:
 
     def __init__(
-            self, user_store: TortoiseUserStore, label_store: TortoiseGitLabelStore, crypto_store: FernetEncryptionHelper, git_manager: RepoFetcher
+        self,
+        user_store: TortoiseUserStore,
+        label_store: TortoiseGitLabelStore,
+        crypto_store: FernetEncryptionHelper,
+        git_manager: RepoFetcher,
     ):
         self.user_store = user_store
         self.label_store = label_store
@@ -139,50 +152,46 @@ class PostGitLabelService:
 
     @classmethod
     def with_dependency(
-            cls,
-            user_store: Annotated[TortoiseUserStore, Depends()],
-            label_store: Annotated[TortoiseGitLabelStore, Depends()],
-            crypto_store: Annotated[FernetEncryptionHelper, Depends(get_encryption_helper)],
-		    git_manager: Annotated[RepoFetcher, Depends()]
+        cls,
+        user_store: Annotated[TortoiseUserStore, Depends()],
+        label_store: Annotated[TortoiseGitLabelStore, Depends()],
+        crypto_store: Annotated[FernetEncryptionHelper, Depends(get_encryption_helper)],
+        git_manager: Annotated[RepoFetcher, Depends()],
     ) -> "PostGitLabelService":
         return cls(
             user_store=user_store,
             label_store=label_store,
             crypto_store=crypto_store,
-            git_manager=git_manager
+            git_manager=git_manager,
         )
 
-    async def add_git_token(self, user_claims:UserClaims, json_payload: GitLabelBase):
+    async def add_git_token(self, user_claims: UserClaims, json_payload: GitLabelBase):
 
         token = json_payload.token_value.replace(" ", "")
         if not token:
-            raise BadRequest(
-                reason=TOKEN_MISSING
-            )
+            raise BadRequest(reason=TOKEN_MISSING)
 
         user = await self.user_store.get_by_user_id(user_id=user_claims.sub)
 
         if not user:
-            raise ResourceNotFound(
-                reason=USER_RESOURCE_NOT_FOUND
-            )
+            raise ResourceNotFound(reason=USER_RESOURCE_NOT_FOUND)
 
-        encrypted_token = self.crypto_store.encrypt_for_user(token, user.encryption_salt)
+        encrypted_token = self.crypto_store.encrypt_for_user(
+            token, user.encryption_salt
+        )
 
         fetcher, response_transformer = retrieve_git_fetcher_or_die(
-	        store=self.git_manager, provider=json_payload.git_hosting
+            store=self.git_manager, provider=json_payload.git_hosting
         )
 
-        retrieved_git_user = fetcher.fetch_repo_user(
-            token=json_payload.token_value
-        )
+        retrieved_git_user = fetcher.fetch_repo_user(token=json_payload.token_value)
 
         if not retrieved_git_user:
-            raise ResourceNotFound(
-                reason=TOKEN_MISSING
-            )
+            raise ResourceNotFound(reason=TOKEN_MISSING)
 
-        transformed_data: GitUserResponse = response_transformer.from_git_user(retrieved_git_user)
+        transformed_data: GitUserResponse = response_transformer.from_git_user(
+            retrieved_git_user
+        )
 
         try:
             created_label = await self.label_store.create_new(
@@ -218,13 +227,14 @@ class DeleteGitLabelService:
             label_store=label_store,
         )
 
-    async def delete_by_git_label_id(self, user_claims: AuthenticatedUserDTO, git_label_id:uuid.UUID) -> str:
+    async def delete_by_git_label_id(
+        self, user_claims: AuthenticatedUserDTO, git_label_id: uuid.UUID
+    ) -> int:
+        deleted_label = await self.label_store.delete_by_id_and_user_id(
+            label_id=git_label_id, user_id=user_claims.id
+        )
 
-        deleted_label = await self.label_store.delete_by_id_and_user_id(label_id=git_label_id, user_id=user_claims.id)
-        
-        if not deleted_label:
-            raise ResourceNotFound(
-                reason=TOKEN_NOT_FOUND
-            )
-        
-        return str(deleted_label.id)
+        if deleted_label <= 0:
+            raise ResourceNotFound(reason=TOKEN_NOT_FOUND)
+
+        return deleted_label

--- a/devdox/tests/unit_test/app/routes/test_git_tokens.py
+++ b/devdox/tests/unit_test/app/routes/test_git_tokens.py
@@ -305,7 +305,7 @@ class TestPostGitLabelRouter__AddGitToken:
 
         response = per_t_client.post(self.route_url, json=payload)
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_add_git_token_unauthorized(self, per_t_client):
         async def _unauth_override():

--- a/devdox/tests/unit_test/test_doubles/app/repository/get_label_repository_doubles.py
+++ b/devdox/tests/unit_test/test_doubles/app/repository/get_label_repository_doubles.py
@@ -1,4 +1,5 @@
 import datetime
+import uuid
 from typing import List, Optional
 from uuid import uuid4
 
@@ -65,6 +66,18 @@ class FakeGitLabelStore(ILabelStore):
         result = GitLabel(**label_model.model_dump())
         self.git_labels.append(result)
         return result
+
+    async def delete_by_id_and_user_id(self, label_id: uuid.UUID, user_id: str) -> GitLabel | None:
+        if "delete_by_id_and_user_id" in self.exceptions:
+            raise self.exceptions["delete_by_id_and_user_id"]
+
+        self.received_calls.append(("delete_by_id_and_user_id", label_id, user_id))
+
+        for idx, label in enumerate(self.git_labels):
+            if label.id == label_id and label.user_id == user_id:
+                return self.git_labels.pop(idx)
+
+        return None
 
 
 def make_fake_git_label(**overrides) -> GitLabel:

--- a/devdox/tests/unit_test/test_doubles/app/repository/get_label_repository_doubles.py
+++ b/devdox/tests/unit_test/test_doubles/app/repository/get_label_repository_doubles.py
@@ -67,17 +67,19 @@ class FakeGitLabelStore(ILabelStore):
         self.git_labels.append(result)
         return result
 
-    async def delete_by_id_and_user_id(self, label_id: uuid.UUID, user_id: str) -> GitLabel | None:
-        if "delete_by_id_and_user_id" in self.exceptions:
-            raise self.exceptions["delete_by_id_and_user_id"]
+    async def delete_by_id_and_user_id(self, label_id: uuid.UUID, user_id: str) -> int:
+        if not label_id or not user_id or not user_id.strip():
+            return -1
 
         self.received_calls.append(("delete_by_id_and_user_id", label_id, user_id))
 
-        for idx, label in enumerate(self.git_labels):
-            if label.id == label_id and label.user_id == user_id:
-                return self.git_labels.pop(idx)
-
-        return None
+        initial_count = len(self.git_labels)
+        self.git_labels = [
+            label
+            for label in self.git_labels
+            if not (label.id == label_id and label.user_id == user_id)
+        ]
+        return initial_count - len(self.git_labels)
 
 
 def make_fake_git_label(**overrides) -> GitLabel:


### PR DESCRIPTION
refactor: Added the servicer/router layer separation

Summary:
- Added `DeleteGitTokenRequest` to serve as the request holder. 

- Added the `delete_by_id_and_user_id` repository method, and added it to the FakeGitLabelStore.

- Added an empty default `__init__` dunder method for repository classes `TortoiseRepoStore`, `TortoiseUserStore`, `TortoiseGitLabelStore`, because when using it with Depends(), FastAPI dependency mechanism will automatically assume its in this form and  cause args and kwargs to show as required query parameters.
  ```
  def __init__(self, *args, **kwargs):
      pass
  ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to delete Git labels by ID for authenticated users.
  * Introduced a new request schema and service to support Git label deletion.

* **Bug Fixes**
  * Updated error response for missing token values to return a 400 Bad Request.

* **Refactor**
  * Streamlined the Git label deletion endpoint to use a dedicated service and request schema.
  * Improved dependency injection handling for repository classes.

* **Tests**
  * Added tests for Git label deletion method covering input validation and deletion outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->