### PR TITLE
Dapa 79 implement the create new api key api

### DIFF
--- a/devdox/app/exceptions/custom_exceptions.py
+++ b/devdox/app/exceptions/custom_exceptions.py
@@ -120,8 +120,8 @@ class UnauthorizedAccess(DevDoxAPIException):
 class BadRequest(DevDoxAPIException):
     http_status = status.HTTP_400_BAD_REQUEST
 
-    def __init__(self, reason=GENERIC_BAD_REQUEST):
-        super().__init__(user_message=reason)
+    def __init__(self, reason=GENERIC_BAD_REQUEST, log_message: Optional[str]= None):
+        super().__init__(user_message=reason, log_message=log_message)
 
 
 class ResourceNotFound(DevDoxAPIException):

--- a/devdox/app/exceptions/custom_exceptions.py
+++ b/devdox/app/exceptions/custom_exceptions.py
@@ -120,7 +120,7 @@ class UnauthorizedAccess(DevDoxAPIException):
 class BadRequest(DevDoxAPIException):
     http_status = status.HTTP_400_BAD_REQUEST
 
-    def __init__(self, reason=GENERIC_BAD_REQUEST, log_message: Optional[str]= None):
+    def __init__(self, reason=GENERIC_BAD_REQUEST, log_message: Optional[str] = None):
         super().__init__(user_message=reason, log_message=log_message)
 
 

--- a/devdox/app/exceptions/exception_constants.py
+++ b/devdox/app/exceptions/exception_constants.py
@@ -16,5 +16,9 @@ MISSING_USER_ID_LOG_MESSAGE = "user_id was None when trying to fetch Git labels.
 MISSING_LABEL_ID_TITLE = "MISSING_LABEL"
 MISSING_LABEL_LOG_MESSAGE = "label was None when trying to fetch Git labels."
 
-UNIQUE_API_KEY_GENERATION_FAILED = "Could not generate a unique API key, please try again."
-FAILED_GENERATE_API_KEY_RETRIES_LOG_MESSAGE = "Failed to generate a unique API key after {attempts} attempts"
+UNIQUE_API_KEY_GENERATION_FAILED = (
+    "Could not generate a unique API key, please try again."
+)
+FAILED_GENERATE_API_KEY_RETRIES_LOG_MESSAGE = (
+    "Failed to generate a unique API key after {attempts} attempts"
+)

--- a/devdox/app/exceptions/exception_constants.py
+++ b/devdox/app/exceptions/exception_constants.py
@@ -15,3 +15,6 @@ MISSING_USER_ID_LOG_MESSAGE = "user_id was None when trying to fetch Git labels.
 
 MISSING_LABEL_ID_TITLE = "MISSING_LABEL"
 MISSING_LABEL_LOG_MESSAGE = "label was None when trying to fetch Git labels."
+
+UNIQUE_API_KEY_GENERATION_FAILED = "Could not generate a unique API key, please try again."
+FAILED_GENERATE_API_KEY_RETRIES_LOG_MESSAGE = "Failed to generate a unique API key after {attempts} attempts"

--- a/devdox/app/repositories/api_key_repository.py
+++ b/devdox/app/repositories/api_key_repository.py
@@ -8,14 +8,15 @@ from app.schemas.api_key_schema import APIKeyCreate
 
 
 class IApiKeyStore(Protocol):
-    
+
     @abstractmethod
     async def query_for_existing_hashes(
         self, hash_key_list: List[str]
     ) -> None | List[str]: ...
-    
+
     @abstractmethod
     async def save_api_key(self, create_model: APIKeyCreate) -> Any: ...
+
 
 class TortoiseApiKeyStore(IApiKeyStore):
 

--- a/devdox/app/repositories/api_key_repository.py
+++ b/devdox/app/repositories/api_key_repository.py
@@ -1,8 +1,7 @@
 from abc import abstractmethod
-from typing import Any, Coroutine, List, Optional, Protocol
+from typing import Any, Protocol
 
 from models import APIKEY
-from tortoise.expressions import Q
 
 from app.schemas.api_key_schema import APIKeyCreate
 

--- a/devdox/app/repositories/api_key_repository.py
+++ b/devdox/app/repositories/api_key_repository.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Any, Coroutine, List, Protocol
+from typing import Any, List, Protocol
 
 from models import APIKEY
 from tortoise.expressions import Q

--- a/devdox/app/repositories/api_key_repository.py
+++ b/devdox/app/repositories/api_key_repository.py
@@ -1,0 +1,46 @@
+from abc import abstractmethod
+from typing import Any, Coroutine, List, Protocol
+
+from models import APIKEY
+from tortoise.expressions import Q
+
+from app.schemas.api_key_schema import APIKeyCreate
+
+
+class IApiKeyStore(Protocol):
+    
+    @abstractmethod
+    async def query_for_existing_hashes(
+        self, hash_key_list: List[str]
+    ) -> None | List[str]: ...
+    
+    @abstractmethod
+    async def save_api_key(self, create_model: APIKeyCreate) -> Any: ...
+
+class TortoiseApiKeyStore(IApiKeyStore):
+
+    def __init__(self):
+        """
+        Have to add this as an empty __init__ to override it, because when using it with Depends(),
+        FastAPI dependency mechanism will automatically assume its
+        ```
+        def __init__(self, *args, **kwargs):
+            pass
+        ```
+        Causing unneeded behavior.
+        """
+        pass
+
+    async def query_for_existing_hashes(
+        self, hash_key_list: List[str]
+    ) -> None | List[str]:
+
+        if not hash_key_list:
+            return None
+
+        return await APIKEY.filter(Q(api_key__in=hash_key_list)).values_list(
+            "api_key", flat=True
+        )
+
+    async def save_api_key(self, create_model: APIKeyCreate) -> APIKEY:
+        return await APIKEY.create(**create_model.model_dump())

--- a/devdox/app/routes/__init__.py
+++ b/devdox/app/routes/__init__.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter
 from app.routes.git_tokens import router as git_tokens
 from app.routes.repos import router as repos
 from app.routes.webhooks import router as webhook_router
+from app.routes.api_keys_route import router as api_keys_router
 
 # Create main router
 router = APIRouter()
@@ -15,3 +16,5 @@ router = APIRouter()
 router.include_router(git_tokens, prefix="/git_tokens", tags=["GitTokens"])
 router.include_router(repos, prefix="/repos", tags=["Repos"])
 router.include_router(webhook_router, prefix="/webhooks", tags=["Webhooks"])
+
+router.include_router(api_keys_router, prefix="/api-keys", tags=["API-Key"])

--- a/devdox/app/routes/api_keys_route.py
+++ b/devdox/app/routes/api_keys_route.py
@@ -1,0 +1,36 @@
+from typing import Annotated, Any, Dict
+
+from fastapi import APIRouter, Depends
+from starlette import status
+from starlette.responses import JSONResponse
+
+from app.services.api_keys_service import PostApiKeyService
+from app.utils import constants
+from app.utils.api_response import APIResponse
+from app.utils.auth import get_authenticated_user, UserClaims
+
+router = APIRouter()
+
+@router.post(
+    "/",
+    response_model=Dict[str, Any],
+    status_code=status.HTTP_201_CREATED,
+    summary="Add a new api token",
+    description="Create a new api token",
+)
+async def add_new_api_key(
+    user_claims: Annotated[UserClaims, Depends(get_authenticated_user)],
+    service: Annotated[
+        PostApiKeyService, Depends(PostApiKeyService.with_dependency)
+    ],
+) -> JSONResponse:
+    """
+    Generate a new API key
+    """
+    db_id, plain_key = await service.generate_api_key(
+        user_claims=user_claims
+    )
+
+    return APIResponse.success(
+        message=constants.API_KEY_GENERATED_SUCCESSFULLY, data={ "id": db_id, "api_key": plain_key }
+    )

--- a/devdox/app/routes/api_keys_route.py
+++ b/devdox/app/routes/api_keys_route.py
@@ -11,6 +11,7 @@ from app.utils.auth import get_authenticated_user, UserClaims
 
 router = APIRouter()
 
+
 @router.post(
     "/",
     response_model=Dict[str, Any],
@@ -20,17 +21,14 @@ router = APIRouter()
 )
 async def add_new_api_key(
     user_claims: Annotated[UserClaims, Depends(get_authenticated_user)],
-    service: Annotated[
-        PostApiKeyService, Depends(PostApiKeyService.with_dependency)
-    ],
+    service: Annotated[PostApiKeyService, Depends(PostApiKeyService.with_dependency)],
 ) -> JSONResponse:
     """
     Generate a new API key
     """
-    db_id, plain_key = await service.generate_api_key(
-        user_claims=user_claims
-    )
+    db_id, plain_key = await service.generate_api_key(user_claims=user_claims)
 
     return APIResponse.success(
-        message=constants.API_KEY_GENERATED_SUCCESSFULLY, data={"id": db_id, "api_key": plain_key}
+        message=constants.API_KEY_GENERATED_SUCCESSFULLY,
+        data={"id": db_id, "api_key": plain_key},
     )

--- a/devdox/app/routes/api_keys_route.py
+++ b/devdox/app/routes/api_keys_route.py
@@ -15,8 +15,8 @@ router = APIRouter()
     "/",
     response_model=Dict[str, Any],
     status_code=status.HTTP_201_CREATED,
-    summary="Add a new api token",
-    description="Create a new api token",
+    summary="Create a new API key",
+    description="Create a new API key for the authenticated user",
 )
 async def add_new_api_key(
     user_claims: Annotated[UserClaims, Depends(get_authenticated_user)],
@@ -32,5 +32,5 @@ async def add_new_api_key(
     )
 
     return APIResponse.success(
-        message=constants.API_KEY_GENERATED_SUCCESSFULLY, data={ "id": db_id, "api_key": plain_key }
+        message=constants.API_KEY_GENERATED_SUCCESSFULLY, data={"id": db_id, "api_key": plain_key}
     )

--- a/devdox/app/schemas/api_key_schema.py
+++ b/devdox/app/schemas/api_key_schema.py
@@ -7,11 +7,14 @@ USER_ID_FIELD_DESCRIPTION = "User identifier (owner of the API key)"
 MASKED_API_KEY_FIELD_DESCRIPTION = "Masked version of the API key"
 IS_ACTIVE_FIELD_DESCRIPTION = "Whether this API key is active or soft deleted"
 
+
 class APIKeyCreate(BaseModel):
     user_id: str = Field(..., description=USER_ID_FIELD_DESCRIPTION)
     api_key: str = Field(..., description=API_KEY_FIELD_DESCRIPTION)
     masked_api_key: str = Field(..., description=MASKED_API_KEY_FIELD_DESCRIPTION)
-    is_active: Optional[bool] = Field(default=True, description=IS_ACTIVE_FIELD_DESCRIPTION)
+    is_active: Optional[bool] = Field(
+        default=True, description=IS_ACTIVE_FIELD_DESCRIPTION
+    )
 
     class Config:
         title = "API Key Create Schema"

--- a/devdox/app/schemas/api_key_schema.py
+++ b/devdox/app/schemas/api_key_schema.py
@@ -1,0 +1,19 @@
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+API_KEY_FIELD_DESCRIPTION = "Hashed API key"
+USER_ID_FIELD_DESCRIPTION = "User identifier (owner of the API key)"
+MASKED_API_KEY_FIELD_DESCRIPTION = "Masked version of the API key"
+IS_ACTIVE_FIELD_DESCRIPTION = "Whether this API key is active or soft deleted"
+
+class APIKeyCreate(BaseModel):
+    user_id: str = Field(..., description=USER_ID_FIELD_DESCRIPTION)
+    api_key: str = Field(..., description=API_KEY_FIELD_DESCRIPTION)
+    masked_api_key: str = Field(..., description=MASKED_API_KEY_FIELD_DESCRIPTION)
+    is_active: Optional[bool] = Field(default=True, description=IS_ACTIVE_FIELD_DESCRIPTION)
+
+    class Config:
+        title = "API Key Create Schema"
+        description = "Used when creating a new API key. Includes the full hashed key along with base fields."
+        from_attributes = True

--- a/devdox/app/services/api_keys_service.py
+++ b/devdox/app/services/api_keys_service.py
@@ -93,7 +93,7 @@ class PostApiKeyService:
         max_generation_attempts = 6
 
         result = None
-        for attempt in range(1, max_generation_attempts + 1):
+        for _ in range(1, max_generation_attempts + 1):
             tmp_result = await self.api_key_manager.generate_unique_api_key()
             if tmp_result:
                 result = tmp_result

--- a/devdox/app/services/api_keys_service.py
+++ b/devdox/app/services/api_keys_service.py
@@ -45,6 +45,10 @@ class APIKeyManager:
     
     async def find_hashes_if_exist(self, hash_key_list) -> set:
         existing = await self.api_key_store.query_for_existing_hashes(hash_key_list)
+        
+        if not existing:
+            return set()
+        
         existing_set = set(existing)
         
         return existing_set

--- a/devdox/app/services/api_keys_service.py
+++ b/devdox/app/services/api_keys_service.py
@@ -1,0 +1,129 @@
+import dataclasses
+import hashlib
+import random
+import string
+from typing import Annotated, Optional
+
+from fastapi import Depends
+
+from app.exceptions.custom_exceptions import BadRequest
+from app.exceptions.exception_constants import FAILED_GENERATE_API_KEY_RETRIES_LOG_MESSAGE, \
+    UNIQUE_API_KEY_GENERATION_FAILED
+from app.repositories.api_key_repository import TortoiseApiKeyStore
+from app.schemas.api_key_schema import APIKeyCreate
+from app.services.git_tokens_service import mask_token
+from app.utils.auth import UserClaims
+
+@dataclasses.dataclass
+class APIKeyManagerReturn:
+    plain: str
+    hashed: str
+    masked: str
+
+class APIKeyManager:
+
+    DEFAULT_MAX_KEY_LENGTH = 16
+    DEFAULT_MAX_CANDIDATE_NUMBER = 5
+    DEFAULT_PREFIX = ""
+
+    def __init__(self, api_key_store:TortoiseApiKeyStore):
+        self.api_key_store = api_key_store
+
+    @staticmethod
+    def hash_key(unhashed_api_key: str) -> str:
+        return hashlib.sha256(unhashed_api_key.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def __generate_plain_key(prefix: str = DEFAULT_PREFIX, length: int = DEFAULT_MAX_KEY_LENGTH) -> str:
+        chars = string.ascii_letters + string.digits
+        random_part = "".join(random.choices(chars, k=length - len(prefix)))
+        return prefix + random_part
+    
+    @staticmethod
+    def mask_api_key(unhashed_key: str) -> str:
+        return mask_token(unhashed_key)
+    
+    async def find_hashes_if_exist(self, hash_key_list) -> set:
+        existing = await self.api_key_store.query_for_existing_hashes(hash_key_list)
+        existing_set = set(existing)
+        
+        return existing_set
+
+    async def generate_unique_api_key(self,
+        prefix: str = DEFAULT_PREFIX, candidates: int = DEFAULT_MAX_CANDIDATE_NUMBER, length: int = DEFAULT_MAX_KEY_LENGTH
+    ) -> Optional[APIKeyManagerReturn]:
+        # Generate candidates
+        plain_keys = [
+            self.__generate_plain_key(prefix=prefix, length=length) for _ in range(candidates)
+        ]
+
+        hashed_keys = [self.hash_key(k) for k in plain_keys]
+
+        # Query existing hashes in DB
+        # (disclaimer: It's rare to have similar hashes even for the same keys, but this is in place for edge cases)
+        existing_set = await self.find_hashes_if_exist(hashed_keys)
+
+        # Select a non-conflicting key
+        for plain, hashed in zip(plain_keys, hashed_keys):
+            if hashed not in existing_set:
+                masked = self.mask_api_key(plain)
+                return APIKeyManagerReturn(
+                    plain=plain,
+                    hashed=hashed,
+                    masked= masked
+                )
+        
+        # If None that means it has failed to find any key, and it's left to the caller how to handle such a case
+        return None
+
+class PostApiKeyService:
+
+    def __init__(
+        self,
+        api_key_store: TortoiseApiKeyStore,
+        api_key_manager: APIKeyManager,
+    ):
+        self.api_key_store = api_key_store
+        self.api_key_manager = api_key_manager
+
+    @classmethod
+    def with_dependency(
+        cls,
+        api_key_store: Annotated[TortoiseApiKeyStore, Depends()],
+    ) -> "PostApiKeyService":
+
+        api_key_manager = APIKeyManager(
+            api_key_store = api_key_store
+        )
+
+        return cls(
+            api_key_store=api_key_store,
+            api_key_manager=api_key_manager,
+        )
+
+    async def generate_api_key(self, user_claims: UserClaims):
+        
+        max_generation_attempts = 3
+        
+        result= None
+        for attempt in range(1, max_generation_attempts + 1):
+            tmp_result = await self.api_key_manager.generate_unique_api_key(candidates=2)
+            if tmp_result:
+                result = tmp_result
+                break
+
+        if not result:
+            raise BadRequest(
+                reason=UNIQUE_API_KEY_GENERATION_FAILED,
+                log_message=FAILED_GENERATE_API_KEY_RETRIES_LOG_MESSAGE.format(attempts=max_generation_attempts)
+            )
+
+        saved_api_key = await self.api_key_store.save_api_key(
+            APIKeyCreate(
+                user_id=user_claims.sub,
+                api_key=result.hashed,
+                masked_api_key=result.masked,
+            )
+        )
+
+        return saved_api_key.id, result.plain

--- a/devdox/app/services/api_keys_service.py
+++ b/devdox/app/services/api_keys_service.py
@@ -1,6 +1,6 @@
 import dataclasses
 import hashlib
-import random
+import secrets
 import string
 from typing import Annotated, Optional
 
@@ -42,7 +42,7 @@ class APIKeyManager:
         prefix: str = DEFAULT_PREFIX, length: int = DEFAULT_MAX_KEY_LENGTH
     ) -> str:
         chars = string.ascii_letters + string.digits
-        random_part = "".join(random.choices(chars, k=length - len(prefix)))
+        random_part = "".join(secrets.choice(chars) for _ in range(length - len(prefix)))
         return prefix + random_part
 
     @staticmethod

--- a/devdox/app/utils/constants.py
+++ b/devdox/app/utils/constants.py
@@ -5,6 +5,7 @@ GITLAB_AUTH_FAILED = "Failed to authenticate with GitLab"
 GITLAB_USER_RETRIEVE_FAILED = "Could not retrieve GitLab user"
 
 TOKEN_SAVED_SUCCESSFULLY = "Token saved successfully"
+API_KEY_GENERATED_SUCCESSFULLY = "API key generated successfully"
 GITLAB_TOKEN_SAVE_FAILED = "Failed to save GitLab token"
 GITHUB_TOKEN_SAVE_FAILED = "Failed to save GitHub token"
 GITHUB_AUTH_FAILED = "Failed to authenticate with GitHub"

--- a/devdox/tests/unit_test/app/services/test_api_keys_service.py
+++ b/devdox/tests/unit_test/app/services/test_api_keys_service.py
@@ -14,8 +14,13 @@ from app.exceptions.exception_constants import (
     UNIQUE_API_KEY_GENERATION_FAILED,
     FAILED_GENERATE_API_KEY_RETRIES_LOG_MESSAGE,
 )
-from tests.unit_test.test_doubles.app.repository.api_key_repository_test_doubles import FakeApiKeyStore
-from tests.unit_test.test_doubles.app.service.api_keys_service_test_doubles import FakeAPIKeyManager
+from tests.unit_test.test_doubles.app.repository.api_key_repository_test_doubles import (
+    FakeApiKeyStore,
+)
+from tests.unit_test.test_doubles.app.service.api_keys_service_test_doubles import (
+    FakeAPIKeyManager,
+)
+
 
 @pytest.mark.asyncio
 class TestAPIKeyManager:
@@ -48,8 +53,14 @@ class TestAPIKeyManager:
     @pytest.mark.asyncio
     async def test_generate_unique_api_key_success(self, monkeypatch):
         # Force deterministic plain keys
-        monkeypatch.setattr(self.manager, "_APIKeyManager__generate_plain_key", lambda prefix, length: "plainkey123456")
-        monkeypatch.setattr(self.manager, "mask_api_key", lambda x: mask_token("plainkey123456"))
+        monkeypatch.setattr(
+            self.manager,
+            "_APIKeyManager__generate_plain_key",
+            lambda prefix, length: "plainkey123456",
+        )
+        monkeypatch.setattr(
+            self.manager, "mask_api_key", lambda x: mask_token("plainkey123456")
+        )
         monkeypatch.setattr(self.manager, "hash_key", lambda x: "hashedkey")
 
         self.fake_store.set_existing_hashes([])
@@ -63,7 +74,11 @@ class TestAPIKeyManager:
 
     @pytest.mark.asyncio
     async def test_generate_unique_api_key_fails_when_all_conflict(self, monkeypatch):
-        monkeypatch.setattr(self.manager, "_APIKeyManager__generate_plain_key", lambda prefix, length: "conflict")
+        monkeypatch.setattr(
+            self.manager,
+            "_APIKeyManager__generate_plain_key",
+            lambda prefix, length: "conflict",
+        )
         monkeypatch.setattr(self.manager, "hash_key", lambda x: "hashed_conflict")
         monkeypatch.setattr(self.manager, "mask_api_key", lambda x: "****flict")
 
@@ -80,8 +95,7 @@ class TestPostApiKeyService:
         self.fake_store = FakeApiKeyStore()
         self.fake_manager = FakeAPIKeyManager(api_key_store=self.fake_store)
         self.service = PostApiKeyService(
-            api_key_store=self.fake_store,
-            api_key_manager=self.fake_manager
+            api_key_store=self.fake_store, api_key_manager=self.fake_manager
         )
         self.user_claims = UserClaims(sub="user123")
 
@@ -107,7 +121,10 @@ class TestPostApiKeyService:
             await self.service.generate_api_key(self.user_claims)
 
         assert exc.value.user_message == UNIQUE_API_KEY_GENERATION_FAILED
-        assert FAILED_GENERATE_API_KEY_RETRIES_LOG_MESSAGE.format(attempts=3) in exc.value.log_message
+        assert (
+            FAILED_GENERATE_API_KEY_RETRIES_LOG_MESSAGE.format(attempts=3)
+            in exc.value.log_message
+        )
 
     async def test_generate_api_key_bubbles_up_store_error(self):
         # Arrange

--- a/devdox/tests/unit_test/app/services/test_api_keys_service.py
+++ b/devdox/tests/unit_test/app/services/test_api_keys_service.py
@@ -1,19 +1,18 @@
+import hashlib
+import re
 from uuid import uuid4
 
 import pytest
 
+from app.exceptions.custom_exceptions import BadRequest
+from app.exceptions.exception_constants import (FAILED_GENERATE_API_KEY_RETRIES_LOG_MESSAGE,
+                                                UNIQUE_API_KEY_GENERATION_FAILED)
 from app.services.api_keys_service import (
     APIKeyManager,
-    APIKeyManagerReturn,
     PostApiKeyService,
 )
 from app.services.git_tokens_service import mask_token
 from app.utils.auth import UserClaims
-from app.exceptions.custom_exceptions import BadRequest
-from app.exceptions.exception_constants import (
-    UNIQUE_API_KEY_GENERATION_FAILED,
-    FAILED_GENERATE_API_KEY_RETRIES_LOG_MESSAGE,
-)
 from tests.unit_test.test_doubles.app.repository.api_key_repository_test_doubles import (
     FakeApiKeyStore,
 )
@@ -21,124 +20,103 @@ from tests.unit_test.test_doubles.app.service.api_keys_service_test_doubles impo
     FakeAPIKeyManager,
 )
 
-
 @pytest.mark.asyncio
 class TestAPIKeyManager:
 
-    def setup_method(self):
-        self.fake_store = FakeApiKeyStore()
-        self.manager = APIKeyManager(api_key_store=self.fake_store)
+    async def test_generate_unique_key_success(self):
+        store = FakeApiKeyStore()
+        manager = APIKeyManager(store)
 
-    def test_hash_key_is_deterministic(self):
-        unhashed = "my-api-key"
-        hashed1 = self.manager.hash_key(unhashed)
-        hashed2 = self.manager.hash_key(unhashed)
-        assert hashed1 == hashed2
-        assert isinstance(hashed1, str)
+        result = await manager.generate_unique_api_key()
 
-    def test_mask_key_adds_asterisks(self):
-        plain = "abcdef123456"
-        masked = self.manager.mask_api_key(plain)
-        assert "*" in masked
-        assert masked.endswith("56")
+        assert result is not None
+        assert result.plain.startswith("dvd_")
+        assert result.hashed == hashlib.sha256(result.plain.encode("utf-8")).hexdigest()
+        assert result.masked == mask_token(result.plain)
 
-    @pytest.mark.asyncio
-    async def test_find_hashes_if_exist_returns_existing(self):
-        hash1 = "hash1"
-        hash2 = "hash2"
-        self.fake_store.set_existing_hashes([hash1])
-        existing = await self.manager.find_hashes_if_exist([hash1, hash2])
-        assert existing == {hash1}
+    async def test_returns_none_if_hash_exists(self):
+        store = FakeApiKeyStore()
+        manager = APIKeyManager(store)
 
-    @pytest.mark.asyncio
-    async def test_generate_unique_api_key_success(self, monkeypatch):
-        # Force deterministic plain keys
-        monkeypatch.setattr(
-            self.manager,
-            "_APIKeyManager__generate_plain_key",
-            lambda prefix, length: "plainkey123456",
-        )
-        monkeypatch.setattr(
-            self.manager, "mask_api_key", lambda x: mask_token("plainkey123456")
-        )
-        monkeypatch.setattr(self.manager, "hash_key", lambda x: "hashedkey")
+        precomputed_key = manager._APIKeyManager__generate_plain_key()
+        precomputed_hash = manager.hash_key(precomputed_key)
+        store.set_existing_hash(precomputed_hash)
 
-        self.fake_store.set_existing_hashes([])
+        # Monkeypatch to return a known key
+        manager._APIKeyManager__generate_plain_key = lambda prefix, length: precomputed_key
 
-        result = await self.manager.generate_unique_api_key(candidates=1)
-
-        assert isinstance(result, APIKeyManagerReturn)
-        assert result.plain == "plainkey123456"
-        assert result.hashed == "hashedkey"
-        assert result.masked == mask_token("plainkey123456")
-
-    @pytest.mark.asyncio
-    async def test_generate_unique_api_key_fails_when_all_conflict(self, monkeypatch):
-        monkeypatch.setattr(
-            self.manager,
-            "_APIKeyManager__generate_plain_key",
-            lambda prefix, length: "conflict",
-        )
-        monkeypatch.setattr(self.manager, "hash_key", lambda x: "hashed_conflict")
-        monkeypatch.setattr(self.manager, "mask_api_key", lambda x: "****flict")
-
-        self.fake_store.set_existing_hashes(["hashed_conflict"])
-
-        result = await self.manager.generate_unique_api_key(candidates=1)
+        result = await manager.generate_unique_api_key()
 
         assert result is None
+
+    async def test_handles_store_exception(self):
+        store = FakeApiKeyStore()
+        store.set_exception("query_for_existing_hashes", RuntimeError("DB error"))
+        manager = APIKeyManager(store)
+
+        with pytest.raises(RuntimeError, match="DB error"):
+            await manager.generate_unique_api_key()
+
+    async def test_generate_key_respects_prefix_and_length(self):
+        store = FakeApiKeyStore()
+        manager = APIKeyManager(store)
+
+        prefix = "test_"
+        length = 20
+        result = await manager.generate_unique_api_key(prefix=prefix, length=length)
+
+        assert result is not None
+        assert result.plain.startswith(prefix)
+        assert len(result.plain) == length
+
+
+class DummyUserClaims:
+    def __init__(self, user_id):
+        self.sub = user_id
 
 
 @pytest.mark.asyncio
 class TestPostApiKeyService:
-    def setup_method(self):
-        self.fake_store = FakeApiKeyStore()
-        self.fake_manager = FakeAPIKeyManager(api_key_store=self.fake_store)
-        self.service = PostApiKeyService(
-            api_key_store=self.fake_store, api_key_manager=self.fake_manager
-        )
-        self.user_claims = UserClaims(sub="user123")
 
     async def test_generate_api_key_success(self):
-        # Arrange
-        self.fake_manager.set_fixed_keys(["key123"])
+        fake_store = FakeApiKeyStore()
+        fake_manager = FakeAPIKeyManager(fake_store)
+        fake_manager.set_fixed_key("dvd_mock_key")
 
-        # Act
-        result_id, result_plain = await self.service.generate_api_key(self.user_claims)
+        service = PostApiKeyService(api_key_store=fake_store, api_key_manager=fake_manager)
+        user_claims = DummyUserClaims("user-123")
 
-        # Assert
-        assert result_plain == "key123"
-        assert isinstance(result_id, uuid4().__class__)
-        assert self.fake_store.stored_keys[0].user_id == "user123"
+        key_id, plain = await service.generate_api_key(user_claims)
+
+        assert plain == "dvd_mock_key"
+        assert any(k.user_id == "user-123" for k in fake_store.stored_keys)
+        assert key_id is not None
 
     async def test_generate_api_key_fails_after_retries(self):
-        # Arrange
-        self.fake_manager.set_fixed_keys(["key123"])
-        self.fake_store.set_existing_hashes(["hashed_key123"])
+        fake_store = FakeApiKeyStore()
+        fake_manager = FakeAPIKeyManager(fake_store)
+        fake_store.set_existing_hash(fake_manager.hash_key("dvd_mock_key"))
+        fake_manager.set_fixed_key("dvd_mock_key")
 
-        # Act & Assert
+        service = PostApiKeyService(api_key_store=fake_store, api_key_manager=fake_manager)
+        user_claims = DummyUserClaims("user-123")
+
         with pytest.raises(BadRequest) as exc:
-            await self.service.generate_api_key(self.user_claims)
+            await service.generate_api_key(user_claims)
 
         assert exc.value.user_message == UNIQUE_API_KEY_GENERATION_FAILED
-        assert (
-            FAILED_GENERATE_API_KEY_RETRIES_LOG_MESSAGE.format(attempts=3)
-            in exc.value.log_message
-        )
+        
+        pattern = FAILED_GENERATE_API_KEY_RETRIES_LOG_MESSAGE.format(attempts = "\d+")
+        assert re.fullmatch(pattern, exc.value.log_message)
 
-    async def test_generate_api_key_bubbles_up_store_error(self):
-        # Arrange
-        self.fake_manager.set_fixed_keys(["key123"])
-        self.fake_store.set_exception("save_api_key", ValueError("fail"))
+    async def test_generate_api_key_raises_on_store_exception(self):
+        fake_store = FakeApiKeyStore()
+        fake_manager = FakeAPIKeyManager(fake_store)
+        fake_manager.set_fixed_key("dvd_mock_key")
+        fake_store.set_exception("save_api_key", RuntimeError("DB error"))
 
-        # Act & Assert
-        with pytest.raises(ValueError, match="fail"):
-            await self.service.generate_api_key(self.user_claims)
+        service = PostApiKeyService(api_key_store=fake_store, api_key_manager=fake_manager)
+        user_claims = DummyUserClaims("user-123")
 
-    async def test_generate_api_key_bubbles_up_manager_error(self):
-        # Arrange
-        self.fake_manager.set_exception("generate_unique_api_key", RuntimeError("boom"))
-
-        # Act & Assert
-        with pytest.raises(RuntimeError, match="boom"):
-            await self.service.generate_api_key(self.user_claims)
+        with pytest.raises(RuntimeError, match="DB error"):
+            await service.generate_api_key(user_claims)

--- a/devdox/tests/unit_test/app/services/test_api_keys_service.py
+++ b/devdox/tests/unit_test/app/services/test_api_keys_service.py
@@ -1,4 +1,3 @@
-import hashlib
 from uuid import uuid4
 
 import pytest

--- a/devdox/tests/unit_test/app/services/test_api_keys_service.py
+++ b/devdox/tests/unit_test/app/services/test_api_keys_service.py
@@ -1,0 +1,128 @@
+import hashlib
+from uuid import uuid4
+
+import pytest
+
+from app.services.api_keys_service import (
+    APIKeyManager,
+    APIKeyManagerReturn,
+    PostApiKeyService,
+)
+from app.services.git_tokens_service import mask_token
+from app.utils.auth import UserClaims
+from app.exceptions.custom_exceptions import BadRequest
+from app.exceptions.exception_constants import (
+    UNIQUE_API_KEY_GENERATION_FAILED,
+    FAILED_GENERATE_API_KEY_RETRIES_LOG_MESSAGE,
+)
+from tests.unit_test.test_doubles.app.repository.api_key_repository_test_doubles import FakeApiKeyStore
+from tests.unit_test.test_doubles.app.service.api_keys_service_test_doubles import FakeAPIKeyManager
+
+@pytest.mark.asyncio
+class TestAPIKeyManager:
+
+    def setup_method(self):
+        self.fake_store = FakeApiKeyStore()
+        self.manager = APIKeyManager(api_key_store=self.fake_store)
+
+    def test_hash_key_is_deterministic(self):
+        unhashed = "my-api-key"
+        hashed1 = self.manager.hash_key(unhashed)
+        hashed2 = self.manager.hash_key(unhashed)
+        assert hashed1 == hashed2
+        assert isinstance(hashed1, str)
+
+    def test_mask_key_adds_asterisks(self):
+        plain = "abcdef123456"
+        masked = self.manager.mask_api_key(plain)
+        assert "*" in masked
+        assert masked.endswith("56")
+
+    @pytest.mark.asyncio
+    async def test_find_hashes_if_exist_returns_existing(self):
+        hash1 = "hash1"
+        hash2 = "hash2"
+        self.fake_store.set_existing_hashes([hash1])
+        existing = await self.manager.find_hashes_if_exist([hash1, hash2])
+        assert existing == {hash1}
+
+    @pytest.mark.asyncio
+    async def test_generate_unique_api_key_success(self, monkeypatch):
+        # Force deterministic plain keys
+        monkeypatch.setattr(self.manager, "_APIKeyManager__generate_plain_key", lambda prefix, length: "plainkey123456")
+        monkeypatch.setattr(self.manager, "mask_api_key", lambda x: mask_token("plainkey123456"))
+        monkeypatch.setattr(self.manager, "hash_key", lambda x: "hashedkey")
+
+        self.fake_store.set_existing_hashes([])
+
+        result = await self.manager.generate_unique_api_key(candidates=1)
+
+        assert isinstance(result, APIKeyManagerReturn)
+        assert result.plain == "plainkey123456"
+        assert result.hashed == "hashedkey"
+        assert result.masked == mask_token("plainkey123456")
+
+    @pytest.mark.asyncio
+    async def test_generate_unique_api_key_fails_when_all_conflict(self, monkeypatch):
+        monkeypatch.setattr(self.manager, "_APIKeyManager__generate_plain_key", lambda prefix, length: "conflict")
+        monkeypatch.setattr(self.manager, "hash_key", lambda x: "hashed_conflict")
+        monkeypatch.setattr(self.manager, "mask_api_key", lambda x: "****flict")
+
+        self.fake_store.set_existing_hashes(["hashed_conflict"])
+
+        result = await self.manager.generate_unique_api_key(candidates=1)
+
+        assert result is None
+
+
+@pytest.mark.asyncio
+class TestPostApiKeyService:
+    def setup_method(self):
+        self.fake_store = FakeApiKeyStore()
+        self.fake_manager = FakeAPIKeyManager(api_key_store=self.fake_store)
+        self.service = PostApiKeyService(
+            api_key_store=self.fake_store,
+            api_key_manager=self.fake_manager
+        )
+        self.user_claims = UserClaims(sub="user123")
+
+    async def test_generate_api_key_success(self):
+        # Arrange
+        self.fake_manager.set_fixed_keys(["key123"])
+
+        # Act
+        result_id, result_plain = await self.service.generate_api_key(self.user_claims)
+
+        # Assert
+        assert result_plain == "key123"
+        assert isinstance(result_id, uuid4().__class__)
+        assert self.fake_store.stored_keys[0].user_id == "user123"
+
+    async def test_generate_api_key_fails_after_retries(self):
+        # Arrange
+        self.fake_manager.set_fixed_keys(["key123"])
+        self.fake_store.set_existing_hashes(["hashed_key123"])
+
+        # Act & Assert
+        with pytest.raises(BadRequest) as exc:
+            await self.service.generate_api_key(self.user_claims)
+
+        assert exc.value.user_message == UNIQUE_API_KEY_GENERATION_FAILED
+        assert FAILED_GENERATE_API_KEY_RETRIES_LOG_MESSAGE.format(attempts=3) in exc.value.log_message
+
+    async def test_generate_api_key_bubbles_up_store_error(self):
+        # Arrange
+        self.fake_manager.set_fixed_keys(["key123"])
+        self.fake_store.set_exception("save_api_key", ValueError("fail"))
+
+        # Act & Assert
+        with pytest.raises(ValueError, match="fail"):
+            await self.service.generate_api_key(self.user_claims)
+
+    async def test_generate_api_key_bubbles_up_manager_error(self):
+        # Arrange
+        self.fake_manager.set_exception("generate_unique_api_key", RuntimeError("boom"))
+
+        # Act & Assert
+        with pytest.raises(RuntimeError, match="boom"):
+            await self.service.generate_api_key(self.user_claims)

--- a/devdox/tests/unit_test/app/services/test_api_keys_service.py
+++ b/devdox/tests/unit_test/app/services/test_api_keys_service.py
@@ -1,6 +1,5 @@
 import hashlib
 import re
-from uuid import uuid4
 
 import pytest
 
@@ -12,13 +11,13 @@ from app.services.api_keys_service import (
     PostApiKeyService,
 )
 from app.services.git_tokens_service import mask_token
-from app.utils.auth import UserClaims
 from tests.unit_test.test_doubles.app.repository.api_key_repository_test_doubles import (
     FakeApiKeyStore,
 )
 from tests.unit_test.test_doubles.app.service.api_keys_service_test_doubles import (
     FakeAPIKeyManager,
 )
+
 
 @pytest.mark.asyncio
 class TestAPIKeyManager:
@@ -106,7 +105,7 @@ class TestPostApiKeyService:
 
         assert exc.value.user_message == UNIQUE_API_KEY_GENERATION_FAILED
         
-        pattern = FAILED_GENERATE_API_KEY_RETRIES_LOG_MESSAGE.format(attempts = "\d+")
+        pattern = FAILED_GENERATE_API_KEY_RETRIES_LOG_MESSAGE.format(attempts ="\d+")
         assert re.fullmatch(pattern, exc.value.log_message)
 
     async def test_generate_api_key_raises_on_store_exception(self):

--- a/devdox/tests/unit_test/test_doubles/app/repository/api_key_repository_test_doubles.py
+++ b/devdox/tests/unit_test/test_doubles/app/repository/api_key_repository_test_doubles.py
@@ -1,7 +1,7 @@
+from datetime import datetime
 from types import SimpleNamespace
 from typing import Any, List, Optional
-from uuid import UUID, uuid4
-from datetime import datetime
+from uuid import uuid4
 
 from app.repositories.api_key_repository import IApiKeyStore
 from app.schemas.api_key_schema import APIKeyCreate

--- a/devdox/tests/unit_test/test_doubles/app/repository/api_key_repository_test_doubles.py
+++ b/devdox/tests/unit_test/test_doubles/app/repository/api_key_repository_test_doubles.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from types import SimpleNamespace
-from typing import Any, List, Optional
+from typing import Any
 from uuid import uuid4
 
 from app.repositories.api_key_repository import IApiKeyStore

--- a/devdox/tests/unit_test/test_doubles/app/repository/api_key_repository_test_doubles.py
+++ b/devdox/tests/unit_test/test_doubles/app/repository/api_key_repository_test_doubles.py
@@ -20,7 +20,9 @@ class FakeApiKeyStore(IApiKeyStore):
     def set_exception(self, method_name: str, exception: Exception):
         self.exceptions[method_name] = exception
 
-    async def query_for_existing_hashes(self, hash_key_list: List[str]) -> Optional[List[str]]:
+    async def query_for_existing_hashes(
+        self, hash_key_list: List[str]
+    ) -> Optional[List[str]]:
         if "query_for_existing_hashes" in self.exceptions:
             raise self.exceptions["query_for_existing_hashes"]
 
@@ -36,14 +38,14 @@ class FakeApiKeyStore(IApiKeyStore):
         self.received_calls.append(("save_api_key", create_model))
 
         fake_entry = SimpleNamespace(
-            id= uuid4(),
-            user_id= create_model.user_id,
-            api_key= create_model.api_key,
-            masked_api_key= create_model.masked_api_key,
-            is_active= True,
-            created_at= datetime.utcnow(),
-            updated_at= datetime.utcnow(),
-            last_used_at= None,
+            id=uuid4(),
+            user_id=create_model.user_id,
+            api_key=create_model.api_key,
+            masked_api_key=create_model.masked_api_key,
+            is_active=True,
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+            last_used_at=None,
         )
         self.stored_keys.append(fake_entry)
         return fake_entry

--- a/devdox/tests/unit_test/test_doubles/app/repository/api_key_repository_test_doubles.py
+++ b/devdox/tests/unit_test/test_doubles/app/repository/api_key_repository_test_doubles.py
@@ -1,0 +1,49 @@
+from types import SimpleNamespace
+from typing import Any, List, Optional
+from uuid import UUID, uuid4
+from datetime import datetime
+
+from app.repositories.api_key_repository import IApiKeyStore
+from app.schemas.api_key_schema import APIKeyCreate
+
+
+class FakeApiKeyStore(IApiKeyStore):
+    def __init__(self):
+        self.stored_keys = []
+        self.existing_hashes = set()
+        self.received_calls = []
+        self.exceptions = {}
+
+    def set_existing_hashes(self, hashes: List[str]):
+        self.existing_hashes = set(hashes)
+
+    def set_exception(self, method_name: str, exception: Exception):
+        self.exceptions[method_name] = exception
+
+    async def query_for_existing_hashes(self, hash_key_list: List[str]) -> Optional[List[str]]:
+        if "query_for_existing_hashes" in self.exceptions:
+            raise self.exceptions["query_for_existing_hashes"]
+
+        self.received_calls.append(("query_for_existing_hashes", hash_key_list))
+
+        matches = [hk for hk in hash_key_list if hk in self.existing_hashes]
+        return matches if matches else None
+
+    async def save_api_key(self, create_model: APIKeyCreate) -> Any:
+        if "save_api_key" in self.exceptions:
+            raise self.exceptions["save_api_key"]
+
+        self.received_calls.append(("save_api_key", create_model))
+
+        fake_entry = SimpleNamespace(
+            id= uuid4(),
+            user_id= create_model.user_id,
+            api_key= create_model.api_key,
+            masked_api_key= create_model.masked_api_key,
+            is_active= True,
+            created_at= datetime.utcnow(),
+            updated_at= datetime.utcnow(),
+            last_used_at= None,
+        )
+        self.stored_keys.append(fake_entry)
+        return fake_entry

--- a/devdox/tests/unit_test/test_doubles/app/repository/api_key_repository_test_doubles.py
+++ b/devdox/tests/unit_test/test_doubles/app/repository/api_key_repository_test_doubles.py
@@ -10,26 +10,23 @@ from app.schemas.api_key_schema import APIKeyCreate
 class FakeApiKeyStore(IApiKeyStore):
     def __init__(self):
         self.stored_keys = []
-        self.existing_hashes = set()
         self.received_calls = []
         self.exceptions = {}
+        self.existing_hash_set = set()
 
-    def set_existing_hashes(self, hashes: List[str]):
-        self.existing_hashes = set(hashes)
+    def set_existing_hash(self, existing_hash: str):
+        self.existing_hash_set.add(existing_hash)
 
     def set_exception(self, method_name: str, exception: Exception):
         self.exceptions[method_name] = exception
 
-    async def query_for_existing_hashes(
-        self, hash_key_list: List[str]
-    ) -> Optional[List[str]]:
+    async def query_for_existing_hashes(self, hash_key: str) -> bool:
         if "query_for_existing_hashes" in self.exceptions:
             raise self.exceptions["query_for_existing_hashes"]
 
-        self.received_calls.append(("query_for_existing_hashes", hash_key_list))
+        self.received_calls.append(("query_for_existing_hashes", hash_key))
 
-        matches = [hk for hk in hash_key_list if hk in self.existing_hashes]
-        return matches if matches else None
+        return hash_key in self.existing_hash_set
 
     async def save_api_key(self, create_model: APIKeyCreate) -> Any:
         if "save_api_key" in self.exceptions:

--- a/devdox/tests/unit_test/test_doubles/app/service/api_keys_service_test_doubles.py
+++ b/devdox/tests/unit_test/test_doubles/app/service/api_keys_service_test_doubles.py
@@ -1,0 +1,61 @@
+from typing import List, Optional, Set
+
+from app.repositories.api_key_repository import IApiKeyStore
+from app.services.api_keys_service import APIKeyManagerReturn
+
+
+class FakeAPIKeyManager:
+    def __init__(self, api_key_store: IApiKeyStore):
+        self.api_key_store = api_key_store
+        self.fixed_keys: List[str] = []
+        self.received_calls = []
+        self.exceptions = {}
+
+    def set_fixed_keys(self, plain_keys: List[str]):
+        self.fixed_keys = plain_keys
+
+    def set_exception(self, method_name: str, exception: Exception):
+        self.exceptions[method_name] = exception
+
+    @staticmethod
+    def hash_key(unhashed_api_key: str) -> str:
+        return "hashed_" + unhashed_api_key
+
+    @staticmethod
+    def mask_api_key(unhashed_key: str) -> str:
+        return "****" + unhashed_key[-4:]
+
+    async def find_hashes_if_exist(self, hash_key_list: List[str]) -> Set[str]:
+        if "find_hashes_if_exist" in self.exceptions:
+            raise self.exceptions["find_hashes_if_exist"]
+
+        self.received_calls.append(("find_hashes_if_exist", hash_key_list))
+        existing = await self.api_key_store.query_for_existing_hashes(hash_key_list)
+        return set(existing or [])
+
+    async def generate_unique_api_key(
+        self,
+        prefix: str = "",
+        candidates: int = 5,
+        length: int = 16
+    ) -> Optional[APIKeyManagerReturn]:
+        if "generate_unique_api_key" in self.exceptions:
+            raise self.exceptions["generate_unique_api_key"]
+
+        self.received_calls.append(("generate_unique_api_key", prefix, candidates, length))
+
+        # Use fixed keys for determinism
+        plain_keys = self.fixed_keys[:candidates]
+
+        hashed_keys = [self.hash_key(k) for k in plain_keys]
+        existing_set = await self.find_hashes_if_exist(hashed_keys)
+
+        for plain, hashed in zip(plain_keys, hashed_keys):
+            if hashed not in existing_set:
+                return APIKeyManagerReturn(
+                    plain=plain,
+                    hashed=hashed,
+                    masked=self.mask_api_key(plain)
+                )
+
+        return None

--- a/devdox/tests/unit_test/test_doubles/app/service/api_keys_service_test_doubles.py
+++ b/devdox/tests/unit_test/test_doubles/app/service/api_keys_service_test_doubles.py
@@ -1,5 +1,5 @@
 import hashlib
-from typing import List, Optional, Set
+from typing import Optional
 
 from app.repositories.api_key_repository import IApiKeyStore
 from app.services.api_keys_service import APIKeyManagerReturn

--- a/devdox/tests/unit_test/test_doubles/app/service/api_keys_service_test_doubles.py
+++ b/devdox/tests/unit_test/test_doubles/app/service/api_keys_service_test_doubles.py
@@ -34,15 +34,14 @@ class FakeAPIKeyManager:
         return set(existing or [])
 
     async def generate_unique_api_key(
-        self,
-        prefix: str = "",
-        candidates: int = 5,
-        length: int = 16
+        self, prefix: str = "", candidates: int = 5, length: int = 16
     ) -> Optional[APIKeyManagerReturn]:
         if "generate_unique_api_key" in self.exceptions:
             raise self.exceptions["generate_unique_api_key"]
 
-        self.received_calls.append(("generate_unique_api_key", prefix, candidates, length))
+        self.received_calls.append(
+            ("generate_unique_api_key", prefix, candidates, length)
+        )
 
         # Use fixed keys for determinism
         plain_keys = self.fixed_keys[:candidates]
@@ -53,9 +52,7 @@ class FakeAPIKeyManager:
         for plain, hashed in zip(plain_keys, hashed_keys):
             if hashed not in existing_set:
                 return APIKeyManagerReturn(
-                    plain=plain,
-                    hashed=hashed,
-                    masked=self.mask_api_key(plain)
+                    plain=plain, hashed=hashed, masked=self.mask_api_key(plain)
                 )
 
         return None


### PR DESCRIPTION
Summary:
- Added the route [POST] /api/v1/api-keys/

- Added aAPI key manager called `APIKeyManager`

- Added service layer

- Added repository for the ApiKey model

- Added tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API key management, including secure generation, hashing, masking, and storage of unique API keys.
  * Introduced a new API endpoint for authenticated users to create API keys and receive the plaintext key upon creation.

* **Bug Fixes**
  * Improved error handling for API key generation failures with clearer user and log messages.

* **Tests**
  * Added comprehensive unit tests and test doubles for API key services to ensure reliability and correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->