### PR TITLE
Dapa 81 implement a get all api

### DIFF
--- a/devdox/app/exceptions/custom_exceptions.py
+++ b/devdox/app/exceptions/custom_exceptions.py
@@ -120,7 +120,7 @@ class UnauthorizedAccess(DevDoxAPIException):
 class BadRequest(DevDoxAPIException):
     http_status = status.HTTP_400_BAD_REQUEST
 
-    def __init__(self, reason=GENERIC_BAD_REQUEST, log_message: Optional[str]= None):
+    def __init__(self, reason=GENERIC_BAD_REQUEST, log_message: Optional[str] = None):
         super().__init__(user_message=reason, log_message=log_message)
 
 

--- a/devdox/app/exceptions/custom_exceptions.py
+++ b/devdox/app/exceptions/custom_exceptions.py
@@ -120,7 +120,7 @@ class UnauthorizedAccess(DevDoxAPIException):
 class BadRequest(DevDoxAPIException):
     http_status = status.HTTP_400_BAD_REQUEST
 
-    def __init__(self, reason=GENERIC_BAD_REQUEST, log_message: Optional[str] = None):
+    def __init__(self, reason=GENERIC_BAD_REQUEST, log_message: Optional[str]= None):
         super().__init__(user_message=reason, log_message=log_message)
 
 

--- a/devdox/app/repositories/api_key.py
+++ b/devdox/app/repositories/api_key.py
@@ -1,6 +1,6 @@
 import uuid
 from abc import abstractmethod
-from typing import Any, Protocol
+from typing import Any, List, Protocol
 
 from models import APIKEY
 
@@ -19,7 +19,9 @@ class IApiKeyStore(Protocol):
     async def set_inactive_by_user_id_and_api_key_id(
         self, user_id, api_key_id
     ) -> int: ...
-
+    
+    @abstractmethod
+    async def get_all_api_keys(self, user_id) -> List[Any]: ...
 
 class TortoiseApiKeyStore(IApiKeyStore):
 
@@ -54,3 +56,10 @@ class TortoiseApiKeyStore(IApiKeyStore):
         return await APIKEY.filter(
             user_id=user_id, id=api_key_id, is_active=True
         ).update(is_active=False)
+    
+    async def get_all_api_keys(self, user_id:str) -> List[APIKEY]:
+
+        if not user_id or not user_id.strip():
+            return []
+
+        return await APIKEY.filter(user_id=user_id, is_active=True).order_by("-created_at").all()

--- a/devdox/app/repositories/api_key.py
+++ b/devdox/app/repositories/api_key.py
@@ -23,6 +23,7 @@ class IApiKeyStore(Protocol):
     @abstractmethod
     async def get_all_api_keys(self, user_id) -> List[Any]: ...
 
+
 class TortoiseApiKeyStore(IApiKeyStore):
 
     def __init__(self):
@@ -56,10 +57,14 @@ class TortoiseApiKeyStore(IApiKeyStore):
         return await APIKEY.filter(
             user_id=user_id, id=api_key_id, is_active=True
         ).update(is_active=False)
-    
-    async def get_all_api_keys(self, user_id:str) -> List[APIKEY]:
+
+    async def get_all_api_keys(self, user_id: str) -> List[APIKEY]:
 
         if not user_id or not user_id.strip():
             return []
 
-        return await APIKEY.filter(user_id=user_id, is_active=True).order_by("-created_at").all()
+        return (
+            await APIKEY.filter(user_id=user_id, is_active=True)
+            .order_by("-created_at")
+            .all()
+        )

--- a/devdox/app/repositories/api_key.py
+++ b/devdox/app/repositories/api_key.py
@@ -19,7 +19,7 @@ class IApiKeyStore(Protocol):
     async def set_inactive_by_user_id_and_api_key_id(
         self, user_id, api_key_id
     ) -> int: ...
-    
+
     @abstractmethod
     async def get_all_api_keys(self, user_id) -> List[Any]: ...
 

--- a/devdox/app/routes/api_keys.py
+++ b/devdox/app/routes/api_keys.py
@@ -62,7 +62,7 @@ async def revoke_api_key(
     summary="Retrieve user api keys",
     description="Retrieves the API Key per user",
 )
-async def revoke_api_key(
+async def get_all_api_keys_for_user(
     user_claims: Annotated[UserClaims, Depends(get_authenticated_user)],
     service: Annotated[GetApiKeyService, Depends(GetApiKeyService.with_dependency)],
 ) -> JSONResponse:
@@ -70,5 +70,5 @@ async def revoke_api_key(
     results = await service.get_api_keys_by_user(user_claims=user_claims)
 
     return APIResponse.success(
-        message=constants.API_KEY_REVOKED_SUCCESSFULLY, data=results
+        message=constants.GENERIC_SUCCESS, data=results
     )

--- a/devdox/app/routes/api_keys.py
+++ b/devdox/app/routes/api_keys.py
@@ -54,6 +54,7 @@ async def revoke_api_key(
 
     return APIResponse.success(message=constants.API_KEY_REVOKED_SUCCESSFULLY)
 
+
 @router.get(
     "/",
     response_model=Dict[str, Any],

--- a/devdox/app/routes/api_keys.py
+++ b/devdox/app/routes/api_keys.py
@@ -63,14 +63,10 @@ async def revoke_api_key(
 )
 async def revoke_api_key(
     user_claims: Annotated[UserClaims, Depends(get_authenticated_user)],
-    service: Annotated[
-        GetApiKeyService, Depends(GetApiKeyService.with_dependency)
-    ],
+    service: Annotated[GetApiKeyService, Depends(GetApiKeyService.with_dependency)],
 ) -> JSONResponse:
 
-    results = await service.get_api_keys_by_user(
-        user_claims=user_claims
-    )
+    results = await service.get_api_keys_by_user(user_claims=user_claims)
 
     return APIResponse.success(
         message=constants.API_KEY_REVOKED_SUCCESSFULLY, data=results

--- a/devdox/app/routes/api_keys.py
+++ b/devdox/app/routes/api_keys.py
@@ -5,7 +5,11 @@ from starlette import status
 from starlette.responses import JSONResponse
 
 from app.schemas.api_key import APIKeyRevokeRequest
-from app.services.api_keys import PostApiKeyService, RevokeApiKeyService
+from app.services.api_keys import (
+    GetApiKeyService,
+    PostApiKeyService,
+    RevokeApiKeyService,
+)
 from app.utils import constants
 from app.utils.api_response import APIResponse
 from app.utils.auth import get_authenticated_user, UserClaims
@@ -49,3 +53,25 @@ async def revoke_api_key(
     await service.revoke_api_key(user_claims=user_claims, api_key_id=request.api_key_id)
 
     return APIResponse.success(message=constants.API_KEY_REVOKED_SUCCESSFULLY)
+
+@router.get(
+    "/",
+    response_model=Dict[str, Any],
+    status_code=status.HTTP_200_OK,
+    summary="Retrieve user api keys",
+    description="Retrieves the API Key per user",
+)
+async def revoke_api_key(
+    user_claims: Annotated[UserClaims, Depends(get_authenticated_user)],
+    service: Annotated[
+        GetApiKeyService, Depends(GetApiKeyService.with_dependency)
+    ],
+) -> JSONResponse:
+
+    results = await service.get_api_keys_by_user(
+        user_claims=user_claims
+    )
+
+    return APIResponse.success(
+        message=constants.API_KEY_REVOKED_SUCCESSFULLY, data=results
+    )

--- a/devdox/app/schemas/api_key.py
+++ b/devdox/app/schemas/api_key.py
@@ -1,5 +1,5 @@
 import uuid
-import uuid
+import datetime
 from typing import Optional
 
 from fastapi.params import Path
@@ -9,6 +9,8 @@ API_KEY_FIELD_DESCRIPTION = "Hashed API key"
 USER_ID_FIELD_DESCRIPTION = "User identifier (owner of the API key)"
 MASKED_API_KEY_FIELD_DESCRIPTION = "Masked version of the API key"
 IS_ACTIVE_FIELD_DESCRIPTION = "Whether this API key is active or soft deleted"
+CREATED_AT_FIELD_DESCRIPTION = "The date and time the API Key was created"
+LAST_USED_AT_FIELD_DESCRIPTION = "The date and time the API Key was last used"
 
 
 class APIKeyCreate(BaseModel):
@@ -33,3 +35,17 @@ class APIKeyRevokeRequest:
         ),
     ):
         self.api_key_id = api_key_id
+
+
+class APIKeyPublicResponse(BaseModel):
+    user_id: str = Field(..., description=USER_ID_FIELD_DESCRIPTION)
+    masked_api_key: str = Field(..., description=MASKED_API_KEY_FIELD_DESCRIPTION)
+    created_at: datetime.datetime = Field(..., description=CREATED_AT_FIELD_DESCRIPTION)
+    last_used_at: Optional[datetime.datetime] = Field(
+        default=None, description=CREATED_AT_FIELD_DESCRIPTION
+    )
+
+    class Config:
+        title = "API Key Public Schema"
+        description = "Used when returning API Key records to the user"
+        from_attributes = True

--- a/devdox/app/schemas/api_key.py
+++ b/devdox/app/schemas/api_key.py
@@ -42,7 +42,7 @@ class APIKeyPublicResponse(BaseModel):
     masked_api_key: str = Field(..., description=MASKED_API_KEY_FIELD_DESCRIPTION)
     created_at: datetime.datetime = Field(..., description=CREATED_AT_FIELD_DESCRIPTION)
     last_used_at: Optional[datetime.datetime] = Field(
-        default=None, description=CREATED_AT_FIELD_DESCRIPTION
+        default=None, description=LAST_USED_AT_FIELD_DESCRIPTION
     )
 
     class Config:

--- a/devdox/app/schemas/api_key.py
+++ b/devdox/app/schemas/api_key.py
@@ -1,4 +1,5 @@
 import uuid
+import uuid
 from typing import Optional
 
 from fastapi.params import Path

--- a/devdox/app/services/api_keys.py
+++ b/devdox/app/services/api_keys.py
@@ -95,12 +95,12 @@ class PostApiKeyService:
         )
 
     async def generate_api_key(self, user_claims: UserClaims):
-        
-        max_generation_attempts = 3
-        
-        result= None
-        for attempt in range(1, max_generation_attempts + 1):
-            tmp_result = await self.api_key_manager.generate_unique_api_key(candidates=2)
+
+        max_generation_attempts = 6
+
+        result = None
+        for _ in range(1, max_generation_attempts + 1):
+            tmp_result = await self.api_key_manager.generate_unique_api_key()
             if tmp_result:
                 result = tmp_result
                 break

--- a/devdox/app/services/api_keys.py
+++ b/devdox/app/services/api_keys.py
@@ -95,12 +95,12 @@ class PostApiKeyService:
         )
 
     async def generate_api_key(self, user_claims: UserClaims):
-
-        max_generation_attempts = 6
-
-        result = None
-        for _ in range(1, max_generation_attempts + 1):
-            tmp_result = await self.api_key_manager.generate_unique_api_key()
+        
+        max_generation_attempts = 3
+        
+        result= None
+        for attempt in range(1, max_generation_attempts + 1):
+            tmp_result = await self.api_key_manager.generate_unique_api_key(candidates=2)
             if tmp_result:
                 result = tmp_result
                 break

--- a/devdox/app/services/api_keys.py
+++ b/devdox/app/services/api_keys.py
@@ -155,6 +155,7 @@ class RevokeApiKeyService:
 
         return deleted_api_key
 
+
 class GetApiKeyService:
 
     def __init__(
@@ -176,9 +177,11 @@ class GetApiKeyService:
     async def get_api_keys_by_user(self, user_claims: UserClaims):
 
         api_keys_list = await self.api_key_store.get_all_api_keys(
-                user_id=user_claims.sub
+            user_id=user_claims.sub
         )
 
-        api_keys_response = [APIKeyPublicResponse.model_validate(api_key) for api_key in api_keys_list]
+        api_keys_response = [
+            APIKeyPublicResponse.model_validate(api_key) for api_key in api_keys_list
+        ]
 
         return api_keys_response

--- a/devdox/tests/unit_test/app/repository/test_api_key_repository.py
+++ b/devdox/tests/unit_test/app/repository/test_api_key_repository.py
@@ -8,9 +8,15 @@ from app.schemas.api_key import APIKeyCreate
 
 import app.repositories.api_key as actual_module_path
 
-PATH_TO_REPOSITORY_APIKEY = f"{actual_module_path.__name__}.{actual_module_path.APIKEY.__name__}"
-PATH_TO_REPOSITORY_FILTER = f"{PATH_TO_REPOSITORY_APIKEY}.{actual_module_path.APIKEY.filter.__name__}"
-PATH_TO_REPOSITORY_CREATE = f"{PATH_TO_REPOSITORY_APIKEY}.{actual_module_path.APIKEY.create.__name__}"
+PATH_TO_REPOSITORY_APIKEY = (
+    f"{actual_module_path.__name__}.{actual_module_path.APIKEY.__name__}"
+)
+PATH_TO_REPOSITORY_FILTER = (
+    f"{PATH_TO_REPOSITORY_APIKEY}.{actual_module_path.APIKEY.filter.__name__}"
+)
+PATH_TO_REPOSITORY_CREATE = (
+    f"{PATH_TO_REPOSITORY_APIKEY}.{actual_module_path.APIKEY.create.__name__}"
+)
 
 
 @pytest.mark.asyncio

--- a/devdox/tests/unit_test/app/repository/test_api_key_repository.py
+++ b/devdox/tests/unit_test/app/repository/test_api_key_repository.py
@@ -1,0 +1,51 @@
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from app.repositories.api_key import TortoiseApiKeyStore
+from app.schemas.api_key import APIKeyCreate
+
+import app.repositories.api_key as actual_module_path
+
+PATH_TO_REPOSITORY_APIKEY = f"{actual_module_path.__name__}.{actual_module_path.APIKEY.__name__}"
+PATH_TO_REPOSITORY_FILTER = f"{PATH_TO_REPOSITORY_APIKEY}.{actual_module_path.APIKEY.filter.__name__}"
+PATH_TO_REPOSITORY_CREATE = f"{PATH_TO_REPOSITORY_APIKEY}.{actual_module_path.APIKEY.create.__name__}"
+
+
+@pytest.mark.asyncio
+class TestTortoiseApiKeyStore:
+
+    async def test_query_for_existing_hashes_returns_false_on_invalid_input(self):
+        store = TortoiseApiKeyStore()
+
+        assert await store.query_for_existing_hashes(None) is False
+        assert await store.query_for_existing_hashes("") is False
+        assert await store.query_for_existing_hashes("   ") is False
+
+    async def test_save_api_key_calls_model_create(self):
+        store = TortoiseApiKeyStore()
+        with patch(PATH_TO_REPOSITORY_CREATE) as mock_create:
+            model = APIKeyCreate(user_id="u", api_key="a", masked_api_key="m")
+            await store.save_api_key(model)
+            mock_create.assert_called_once_with(**model.model_dump())
+
+    async def test_set_inactive_returns_negative_on_invalid_input(self):
+        store = TortoiseApiKeyStore()
+
+        invalid_cases = [
+            (None, uuid.uuid4()),
+            (" ", uuid.uuid4()),
+            ("user", None),
+        ]
+
+        for user_id, key_id in invalid_cases:
+            result = await store.set_inactive_by_user_id_and_api_key_id(user_id, key_id)
+            assert result == -1
+
+    async def test_get_all_api_keys_returns_empty_on_blank_user_id(self):
+        store = TortoiseApiKeyStore()
+
+        assert await store.get_all_api_keys(None) == []
+        assert await store.get_all_api_keys("") == []
+        assert await store.get_all_api_keys("  ") == []

--- a/devdox/tests/unit_test/app/repository/test_git_label_repository.py
+++ b/devdox/tests/unit_test/app/repository/test_git_label_repository.py
@@ -4,16 +4,16 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from app.exceptions.custom_exceptions import DevDoxAPIException
-from app.repositories.git_label import TortoiseGitLabelStore
+import app.repositories.git_label as actual_module_path
 
-path_to_actual_module = "app.repositories.git_label"
+PATH_TO_ACTUAL_MODULE = actual_module_path.__name__
 
 
 @pytest.mark.asyncio
 class TestTortoiseGitLabelStore:
 
     def setup_method(self):
-        self.store = TortoiseGitLabelStore()
+        self.store = actual_module_path.TortoiseGitLabelStore()
 
     async def test_raises_when_user_id_is_none(self):
         with pytest.raises(DevDoxAPIException) as exc:
@@ -98,7 +98,7 @@ class TestTortoiseGitLabelStore:
         )
         assert result == -1
 
-    @patch(f"{path_to_actual_module}.GitLabel.filter")
+    @patch(f"{PATH_TO_ACTUAL_MODULE}.GitLabel.filter")
     async def test_delete_by_id_and_user_id_returns_zero_if_no_rows_deleted(
         self, mock_filter
     ):
@@ -111,7 +111,7 @@ class TestTortoiseGitLabelStore:
         )
         assert result == 0
 
-    @patch(f"{path_to_actual_module}.GitLabel.filter")
+    @patch(f"{PATH_TO_ACTUAL_MODULE}.GitLabel.filter")
     async def test_delete_by_id_and_user_id_returns_row_count_on_success(
         self, mock_filter
     ):

--- a/devdox/tests/unit_test/app/routes/conftest.py
+++ b/devdox/tests/unit_test/app/routes/conftest.py
@@ -10,19 +10,23 @@ from app.utils.auth import get_authenticated_user, UserClaims
 def test_client():
     yield TestClient(app)
 
+
 @pytest.fixture(scope="module")
 def permissible_test_client():
     """Prevents pytest from automatically handling exceptions as soon as they happen"""
     client = TestClient(app, raise_server_exceptions=False)
     yield client
 
+
 @pytest.fixture
 def override_auth_user():
     async def _override():
         return UserClaims(sub="user123")
+
     app.dependency_overrides[get_authenticated_user] = _override
     yield
     app.dependency_overrides.clear()
+
 
 @pytest.fixture
 def override_auth_user_unauthorized():

--- a/devdox/tests/unit_test/app/routes/conftest.py
+++ b/devdox/tests/unit_test/app/routes/conftest.py
@@ -1,0 +1,36 @@
+import pytest
+from starlette.testclient import TestClient
+
+from app.exceptions.custom_exceptions import UnauthorizedAccess
+from app.main import app
+from app.utils.auth import get_authenticated_user, UserClaims
+
+
+@pytest.fixture(scope="module")
+def test_client():
+    yield TestClient(app)
+
+@pytest.fixture(scope="module")
+def permissible_test_client():
+    """Prevents pytest from automatically handling exceptions as soon as they happen"""
+    client = TestClient(app, raise_server_exceptions=False)
+    yield client
+
+@pytest.fixture
+def override_auth_user():
+    async def _override():
+        return UserClaims(sub="user123")
+    app.dependency_overrides[get_authenticated_user] = _override
+    yield
+    app.dependency_overrides.clear()
+
+@pytest.fixture
+def override_auth_user_unauthorized():
+    async def _override():
+        raise UnauthorizedAccess("Invalid token")
+
+    app.dependency_overrides[get_authenticated_user] = _override
+    try:
+        yield
+    finally:
+        app.dependency_overrides.clear()

--- a/devdox/tests/unit_test/app/routes/test_api_keys_route.py
+++ b/devdox/tests/unit_test/app/routes/test_api_keys_route.py
@@ -56,7 +56,6 @@ def override_revoke_service_success():
     yield store, fake_key_id
     app.dependency_overrides.clear()
 
-
 @pytest.fixture
 def override_revoke_service_not_found():
     store = FakeApiKeyStore()  # no matching keys stored

--- a/devdox/tests/unit_test/app/routes/test_api_keys_route.py
+++ b/devdox/tests/unit_test/app/routes/test_api_keys_route.py
@@ -10,7 +10,10 @@ from app.services.api_keys import GetApiKeyService, RevokeApiKeyService
 from app.utils.auth import UserClaims
 from app.utils.constants import API_KEY_REVOKED_SUCCESSFULLY
 
-from tests.unit_test.test_doubles.app.repository.api_key_repository_test_doubles import FakeApiKeyStore
+from tests.unit_test.test_doubles.app.repository.api_key_repository_test_doubles import (
+    FakeApiKeyStore,
+)
+
 
 class TestRevokeApiKeyRouter:
 
@@ -44,25 +47,37 @@ class TestRevokeApiKeyRouter:
         yield
         app.dependency_overrides.clear()
 
-    def test_successful_revoke(self, test_client, override_auth_user, override_revoke_service_success):
+    def test_successful_revoke(
+        self, test_client, override_auth_user, override_revoke_service_success
+    ):
         _, fake_key_id = override_revoke_service_success
         response = test_client.delete(f"{self.route_url}{fake_key_id}")
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["success"] is True
         assert response.json()["message"] == API_KEY_REVOKED_SUCCESSFULLY
 
-    def test_revoke_not_found(self, test_client, override_auth_user, override_revoke_service_not_found):
+    def test_revoke_not_found(
+        self, test_client, override_auth_user, override_revoke_service_not_found
+    ):
         response = test_client.delete(f"{self.route_url}{uuid.uuid4()}")
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
-    def test_revoke_unauthorized(self, test_client, override_auth_user_unauthorized, override_revoke_service_success):
+    def test_revoke_unauthorized(
+        self,
+        test_client,
+        override_auth_user_unauthorized,
+        override_revoke_service_success,
+    ):
         _, fake_key_id = override_revoke_service_success
         response = test_client.delete(f"{self.route_url}{fake_key_id}")
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_invalid_uuid_path(self, test_client, override_auth_user, override_revoke_service_success):
+    def test_invalid_uuid_path(
+        self, test_client, override_auth_user, override_revoke_service_success
+    ):
         response = test_client.delete(f"{self.route_url}not-a-uuid")
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
 
 class FakeGetApiKeyService:
     def __init__(self):
@@ -104,7 +119,7 @@ class TestGetApiKeyRouter:
             return service
 
         app.dependency_overrides[GetApiKeyService.with_dependency] = _override
-        
+
         try:
             yield
         finally:
@@ -116,7 +131,7 @@ class TestGetApiKeyRouter:
             return FakeGetApiKeyService()  # returns empty list by default
 
         app.dependency_overrides[GetApiKeyService.with_dependency] = _override
-        
+
         try:
             yield
         finally:
@@ -135,7 +150,9 @@ class TestGetApiKeyRouter:
         finally:
             app.dependency_overrides.clear()
 
-    def test_successful_get_keys(self, test_client, override_auth_user, override_get_service_success):
+    def test_successful_get_keys(
+        self, test_client, override_auth_user, override_get_service_success
+    ):
         response = test_client.get(self.route_url)
         assert response.status_code == status.HTTP_200_OK
         body = response.json()
@@ -145,7 +162,9 @@ class TestGetApiKeyRouter:
         assert isinstance(body["data"], list)
         assert body["data"][0]["user_id"] == "user123"
 
-    def test_empty_keys_list(self, test_client, override_auth_user, override_get_service_empty):
+    def test_empty_keys_list(
+        self, test_client, override_auth_user, override_get_service_empty
+    ):
         response = test_client.get(self.route_url)
         assert response.status_code == status.HTTP_200_OK
         body = response.json()
@@ -153,10 +172,14 @@ class TestGetApiKeyRouter:
         assert body["message"] == API_KEY_REVOKED_SUCCESSFULLY
         assert body["data"] == []
 
-    def test_service_failure_raises_503(self, permissible_test_client, override_auth_user, override_get_service_failure):
+    def test_service_failure_raises_503(
+        self, permissible_test_client, override_auth_user, override_get_service_failure
+    ):
         response = permissible_test_client.get(self.route_url)
         assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
 
-    def test_unauthorized_access(self, test_client, override_auth_user_unauthorized, override_get_service_success):
+    def test_unauthorized_access(
+        self, test_client, override_auth_user_unauthorized, override_get_service_success
+    ):
         response = test_client.get(self.route_url)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/devdox/tests/unit_test/app/routes/test_api_keys_route.py
+++ b/devdox/tests/unit_test/app/routes/test_api_keys_route.py
@@ -1,102 +1,162 @@
+import datetime
 import uuid
 import pytest
 from types import SimpleNamespace
 from fastapi import status
-from fastapi.testclient import TestClient
 
 from app.main import app
-from app.services.api_keys import RevokeApiKeyService
-from app.utils.auth import UserClaims, get_authenticated_user
+from app.schemas.api_key import APIKeyPublicResponse
+from app.services.api_keys import GetApiKeyService, RevokeApiKeyService
+from app.utils.auth import UserClaims
 from app.utils.constants import API_KEY_REVOKED_SUCCESSFULLY
-from app.exceptions.custom_exceptions import UnauthorizedAccess
 
-from tests.unit_test.test_doubles.app.repository.api_key_repository_test_doubles import (
-    FakeApiKeyStore,
-)
-
-
-@pytest.fixture(scope="module")
-def client():
-    return TestClient(app)
-
-
-@pytest.fixture
-def override_auth_user():
-    async def _override():
-        return UserClaims(sub="user123")
-
-    app.dependency_overrides[get_authenticated_user] = _override
-    yield
-    app.dependency_overrides.clear()
-
-
-@pytest.fixture
-def override_auth_user_unauth():
-    async def _override():
-        raise UnauthorizedAccess("Invalid token")
-
-    app.dependency_overrides[get_authenticated_user] = _override
-    yield
-    app.dependency_overrides.clear()
-
-
-@pytest.fixture
-def override_revoke_service_success():
-    store = FakeApiKeyStore()
-    fake_key_id = uuid.uuid4()
-    store.stored_keys.append(
-        SimpleNamespace(id=fake_key_id, user_id="user123", is_active=True)
-    )
-    service = RevokeApiKeyService(api_key_store=store)
-
-    def _override():
-        return service
-
-    app.dependency_overrides[RevokeApiKeyService.with_dependency] = _override
-    yield store, fake_key_id
-    app.dependency_overrides.clear()
-
-@pytest.fixture
-def override_revoke_service_not_found():
-    store = FakeApiKeyStore()  # no matching keys stored
-    service = RevokeApiKeyService(api_key_store=store)
-
-    def _override():
-        return service
-
-    app.dependency_overrides[RevokeApiKeyService.with_dependency] = _override
-    yield
-    app.dependency_overrides.clear()
-
+from tests.unit_test.test_doubles.app.repository.api_key_repository_test_doubles import FakeApiKeyStore
 
 class TestRevokeApiKeyRouter:
 
     route_url = "/api/v1/api-keys/"
 
-    def test_successful_revoke(
-        self, client, override_auth_user, override_revoke_service_success
-    ):
+    @pytest.fixture
+    def override_revoke_service_success(self):
+        store = FakeApiKeyStore()
+        fake_key_id = uuid.uuid4()
+        store.stored_keys.append(
+            SimpleNamespace(id=fake_key_id, user_id="user123", is_active=True)
+        )
+        service = RevokeApiKeyService(api_key_store=store)
+
+        def _override():
+            return service
+
+        app.dependency_overrides[RevokeApiKeyService.with_dependency] = _override
+        yield store, fake_key_id
+        app.dependency_overrides.clear()
+
+    @pytest.fixture
+    def override_revoke_service_not_found(self):
+        store = FakeApiKeyStore()  # no matching keys stored
+        service = RevokeApiKeyService(api_key_store=store)
+
+        def _override():
+            return service
+
+        app.dependency_overrides[RevokeApiKeyService.with_dependency] = _override
+        yield
+        app.dependency_overrides.clear()
+
+    def test_successful_revoke(self, test_client, override_auth_user, override_revoke_service_success):
         _, fake_key_id = override_revoke_service_success
-        response = client.delete(f"{self.route_url}{fake_key_id}")
+        response = test_client.delete(f"{self.route_url}{fake_key_id}")
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["success"] is True
         assert response.json()["message"] == API_KEY_REVOKED_SUCCESSFULLY
 
-    def test_revoke_not_found(
-        self, client, override_auth_user, override_revoke_service_not_found
-    ):
-        response = client.delete(f"{self.route_url}{uuid.uuid4()}")
+    def test_revoke_not_found(self, test_client, override_auth_user, override_revoke_service_not_found):
+        response = test_client.delete(f"{self.route_url}{uuid.uuid4()}")
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
-    def test_revoke_unauthorized(
-        self, client, override_auth_user_unauth, override_revoke_service_success
-    ):
+    def test_revoke_unauthorized(self, test_client, override_auth_user_unauthorized, override_revoke_service_success):
         _, fake_key_id = override_revoke_service_success
-        response = client.delete(f"{self.route_url}{fake_key_id}")
+        response = test_client.delete(f"{self.route_url}{fake_key_id}")
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_invalid_uuid_path(
-        self, client, override_auth_user, override_revoke_service_success
-    ):
-        response = client.delete(f"{self.route_url}not-a-uuid")
+    def test_invalid_uuid_path(self, test_client, override_auth_user, override_revoke_service_success):
+        response = test_client.delete(f"{self.route_url}not-a-uuid")
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+class FakeGetApiKeyService:
+    def __init__(self):
+        self.return_keys = []
+        self.should_raise = False
+        self.received_calls = []
+
+    def set_keys(self, keys):
+        self.return_keys = keys
+
+    def set_exception(self):
+        self.should_raise = True
+
+    async def get_api_keys_by_user(self, user_claims: UserClaims):
+        self.received_calls.append(user_claims.sub)
+        if self.should_raise:
+            raise RuntimeError("Service failure")
+        return self.return_keys
+
+
+class TestGetApiKeyRouter:
+
+    route_url = "/api/v1/api-keys/"
+
+    @pytest.fixture
+    def override_get_service_success(self):
+        def _override():
+            service = FakeGetApiKeyService()
+            service.set_keys(
+                [
+                    APIKeyPublicResponse(
+                        user_id="user123",
+                        masked_api_key="****abcd",
+                        created_at=datetime.datetime.now(datetime.UTC),
+                        last_used_at=datetime.datetime.now(datetime.UTC),
+                    )
+                ]
+            )
+            return service
+
+        app.dependency_overrides[GetApiKeyService.with_dependency] = _override
+        
+        try:
+            yield
+        finally:
+            app.dependency_overrides.clear()
+
+    @pytest.fixture
+    def override_get_service_empty(self):
+        def _override():
+            return FakeGetApiKeyService()  # returns empty list by default
+
+        app.dependency_overrides[GetApiKeyService.with_dependency] = _override
+        
+        try:
+            yield
+        finally:
+            app.dependency_overrides.clear()
+
+    @pytest.fixture
+    def override_get_service_failure(self):
+        def _override():
+            service = FakeGetApiKeyService()
+            service.set_exception()
+            return service
+
+        app.dependency_overrides[GetApiKeyService.with_dependency] = _override
+        try:
+            yield
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_successful_get_keys(self, test_client, override_auth_user, override_get_service_success):
+        response = test_client.get(self.route_url)
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["success"] is True
+        assert body["message"] == API_KEY_REVOKED_SUCCESSFULLY
+        assert "data" in body
+        assert isinstance(body["data"], list)
+        assert body["data"][0]["user_id"] == "user123"
+
+    def test_empty_keys_list(self, test_client, override_auth_user, override_get_service_empty):
+        response = test_client.get(self.route_url)
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["success"] is True
+        assert body["message"] == API_KEY_REVOKED_SUCCESSFULLY
+        assert body["data"] == []
+
+    def test_service_failure_raises_503(self, permissible_test_client, override_auth_user, override_get_service_failure):
+        response = permissible_test_client.get(self.route_url)
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+
+    def test_unauthorized_access(self, test_client, override_auth_user_unauthorized, override_get_service_success):
+        response = test_client.get(self.route_url)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/devdox/tests/unit_test/app/routes/test_api_keys_route.py
+++ b/devdox/tests/unit_test/app/routes/test_api_keys_route.py
@@ -8,7 +8,7 @@ from app.main import app
 from app.schemas.api_key import APIKeyPublicResponse
 from app.services.api_keys import GetApiKeyService, RevokeApiKeyService
 from app.utils.auth import UserClaims
-from app.utils.constants import API_KEY_REVOKED_SUCCESSFULLY
+from app.utils.constants import API_KEY_REVOKED_SUCCESSFULLY, GENERIC_SUCCESS
 
 from tests.unit_test.test_doubles.app.repository.api_key_repository_test_doubles import (
     FakeApiKeyStore,
@@ -157,7 +157,7 @@ class TestGetApiKeyRouter:
         assert response.status_code == status.HTTP_200_OK
         body = response.json()
         assert body["success"] is True
-        assert body["message"] == API_KEY_REVOKED_SUCCESSFULLY
+        assert body["message"] == GENERIC_SUCCESS
         assert "data" in body
         assert isinstance(body["data"], list)
         assert body["data"][0]["user_id"] == "user123"
@@ -169,7 +169,7 @@ class TestGetApiKeyRouter:
         assert response.status_code == status.HTTP_200_OK
         body = response.json()
         assert body["success"] is True
-        assert body["message"] == API_KEY_REVOKED_SUCCESSFULLY
+        assert body["message"] == GENERIC_SUCCESS
         assert body["data"] == []
 
     def test_service_failure_raises_503(

--- a/devdox/tests/unit_test/app/routes/test_git_tokens.py
+++ b/devdox/tests/unit_test/app/routes/test_git_tokens.py
@@ -29,6 +29,7 @@ from tests.unit_test.test_doubles.app.utils.repo_fetcher_doubles import (
     FakeRepoFetcher,
 )
 
+
 class TestGetGitLabelsRouter:
 
     route_url = "/api/v1/git_tokens/"
@@ -103,7 +104,10 @@ class TestGetGitLabelsRouter:
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_get_git_labels_service_raises(
-        self, permissible_test_client, override_auth_user, override_git_label_service_exception
+        self,
+        permissible_test_client,
+        override_auth_user,
+        override_git_label_service_exception,
     ):
         response = permissible_test_client.get(f"{self.route_url}?limit=10&offset=0")
         assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
@@ -292,7 +296,9 @@ class TestPostGitLabelRouter__AddGitToken:
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    def test_add_git_token_missing_token_value(self, permissible_test_client, override_auth_user):
+    def test_add_git_token_missing_token_value(
+        self, permissible_test_client, override_auth_user
+    ):
         payload = {"label": "label1", "token_value": " ", "git_hosting": "GITHUB"}
 
         response = permissible_test_client.post(self.route_url, json=payload)
@@ -313,7 +319,9 @@ class TestPostGitLabelRouter__AddGitToken:
         finally:
             app.dependency_overrides.clear()
 
-    def test_add_git_token_validation_error(self, permissible_test_client, override_auth_user):
+    def test_add_git_token_validation_error(
+        self, permissible_test_client, override_auth_user
+    ):
         payload = {"token_value": "abc123"}
 
         response = permissible_test_client.post(self.route_url, json=payload)
@@ -362,7 +370,10 @@ class TestDeleteGitLabel:
             app.dependency_overrides.clear()
 
     def test_delete_git_label_success(
-        self, test_client: TestClient, override_auth_user, override_delete_service_success
+        self,
+        test_client: TestClient,
+        override_auth_user,
+        override_delete_service_success,
     ):
         response = test_client.delete(self.route_url)
 

--- a/devdox/tests/unit_test/app/services/test_api_keys_service.py
+++ b/devdox/tests/unit_test/app/services/test_api_keys_service.py
@@ -8,8 +8,10 @@ import pytest
 from pydantic import ValidationError
 
 from app.exceptions.custom_exceptions import BadRequest, ResourceNotFound
-from app.exceptions.exception_constants import (FAILED_GENERATE_API_KEY_RETRIES_LOG_MESSAGE,
-                                                UNIQUE_API_KEY_GENERATION_FAILED)
+from app.exceptions.exception_constants import (
+    FAILED_GENERATE_API_KEY_RETRIES_LOG_MESSAGE,
+    UNIQUE_API_KEY_GENERATION_FAILED,
+)
 from app.schemas.api_key import APIKeyPublicResponse
 from app.services.api_keys import (
     APIKeyManager,
@@ -172,7 +174,7 @@ class TestRevokeApiKeyService:
 
         with pytest.raises(RuntimeError, match="DB Error"):
             await service.revoke_api_key(claims, api_key_id=uuid4())
-            
+
 
 @pytest.mark.asyncio
 class TestAPIKeyPublicResponse:
@@ -204,9 +206,8 @@ class TestAPIKeyPublicResponse:
     def test_missing_required_field_raises(self):
         now = datetime.datetime.utcnow()
         with pytest.raises(ValidationError):
-            APIKeyPublicResponse(
-                masked_api_key="****abcd", created_at=now
-            )
+            APIKeyPublicResponse(masked_api_key="****abcd", created_at=now)
+
 
 @pytest.mark.asyncio
 class TestGetApiKeyService:

--- a/devdox/tests/unit_test/app/services/test_api_keys_service.py
+++ b/devdox/tests/unit_test/app/services/test_api_keys_service.py
@@ -1,17 +1,19 @@
+import datetime
 import hashlib
 import re
 from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
+from pydantic import ValidationError
 
 from app.exceptions.custom_exceptions import BadRequest, ResourceNotFound
-from app.exceptions.exception_constants import (
-    FAILED_GENERATE_API_KEY_RETRIES_LOG_MESSAGE,
-    UNIQUE_API_KEY_GENERATION_FAILED,
-)
+from app.exceptions.exception_constants import (FAILED_GENERATE_API_KEY_RETRIES_LOG_MESSAGE,
+                                                UNIQUE_API_KEY_GENERATION_FAILED)
+from app.schemas.api_key import APIKeyPublicResponse
 from app.services.api_keys import (
     APIKeyManager,
+    GetApiKeyService,
     PostApiKeyService,
     RevokeApiKeyService,
 )
@@ -170,3 +172,82 @@ class TestRevokeApiKeyService:
 
         with pytest.raises(RuntimeError, match="DB Error"):
             await service.revoke_api_key(claims, api_key_id=uuid4())
+            
+
+@pytest.mark.asyncio
+class TestAPIKeyPublicResponse:
+
+    def test_valid_instantiation(self):
+        now = datetime.datetime.utcnow()
+        response = APIKeyPublicResponse(
+            user_id="user123",
+            masked_api_key="****abcd",
+            created_at=now,
+            last_used_at=now,
+        )
+
+        assert response.user_id == "user123"
+        assert response.masked_api_key == "****abcd"
+        assert response.created_at == now
+        assert response.last_used_at == now
+
+    def test_optional_last_used_at_none(self):
+        now = datetime.datetime.utcnow()
+        response = APIKeyPublicResponse(
+            user_id="user123",
+            masked_api_key="****abcd",
+            created_at=now,
+        )
+
+        assert response.last_used_at is None
+
+    def test_missing_required_field_raises(self):
+        now = datetime.datetime.utcnow()
+        with pytest.raises(ValidationError):
+            APIKeyPublicResponse(
+                masked_api_key="****abcd", created_at=now
+            )
+
+@pytest.mark.asyncio
+class TestGetApiKeyService:
+
+    async def test_get_api_keys_by_user_returns_expected_models(self):
+        store = FakeApiKeyStore()
+        now = datetime.datetime.utcnow()
+        store.stored_keys = [
+            SimpleNamespace(
+                id="1",
+                user_id="user123",
+                masked_api_key="****abcd",
+                is_active=True,
+                created_at=now,
+                updated_at=now,
+                last_used_at=None,
+            )
+        ]
+        service = GetApiKeyService(api_key_store=store)
+        claims = UserClaims(sub="user123")
+
+        result = await service.get_api_keys_by_user(user_claims=claims)
+
+        assert len(result) == 1
+        assert isinstance(result[0], APIKeyPublicResponse)
+        assert result[0].user_id == "user123"
+
+    async def test_returns_empty_list_when_no_keys(self):
+        store = FakeApiKeyStore()
+        service = GetApiKeyService(api_key_store=store)
+        claims = UserClaims(sub="user123")
+
+        result = await service.get_api_keys_by_user(user_claims=claims)
+
+        assert result == []
+
+    async def test_get_api_keys_by_user_propagates_exception(self):
+        store = FakeApiKeyStore()
+        store.set_exception("get_all_api_keys", RuntimeError("store error"))
+        service = GetApiKeyService(api_key_store=store)
+        claims = UserClaims(sub="user123")
+
+        with pytest.raises(RuntimeError, match="store error"):
+            await service.get_api_keys_by_user(user_claims=claims)

--- a/devdox/tests/unit_test/app/services/test_git_tokens_service.py
+++ b/devdox/tests/unit_test/app/services/test_git_tokens_service.py
@@ -1,7 +1,6 @@
 import uuid
 
 import pytest
-from models import User
 from tortoise.exceptions import IntegrityError
 
 from app.exceptions.custom_exceptions import BadRequest, ResourceNotFound

--- a/devdox/tests/unit_test/test_doubles/app/repository/api_key_repository_test_doubles.py
+++ b/devdox/tests/unit_test/test_doubles/app/repository/api_key_repository_test_doubles.py
@@ -68,7 +68,7 @@ class FakeApiKeyStore(IApiKeyStore):
                 key.is_active = False
                 updated += 1
         return updated
-    
+
     async def get_all_api_keys(self, user_id) -> List[Any]:
         if "get_all_api_keys" in self.exceptions:
             raise self.exceptions["get_all_api_keys"]


### PR DESCRIPTION
Summary:
- Added the new route [GET] `/api/v1/api-keys/` which is supposed to get all the `is_active` API Keys per `user_id` which we get via the Jwt Token.

- Added a new repository method `get_all_api_keys` to `TortoiseApiKeyStore` and the test double `FakeApiKeyStore`

- Added behavioural tests for Repository

- Added tests for the service part of the API  

- Added tests for the route part of the API

- unified repeated fixtures into a `conftest` local to the routes test's, effected test modules include:
  - `test_api_keys_route.py`
  - `test_git_tokens.py`

- Introduced a more type safe and easy to handle way to write patch paths, eliminating the need to have to write string paths that are very brittle, effected tests:
  - `test_api_key_repository.py`
  - `test_git_label_repository.py`

- Removed unused import from `test_git_tokens_service.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an endpoint for users to retrieve all their API keys, including creation and last-used timestamps.
  * Introduced a public response schema for displaying API key details to users.
  * Implemented a service to fetch API keys for authenticated users.

* **Bug Fixes**
  * Improved input validation for API key retrieval, ensuring empty or invalid user IDs return an empty result.

* **Tests**
  * Added comprehensive tests for API key repository, service, and route logic, including input validation and error scenarios.
  * Added tests for the new API key retrieval endpoint covering success, empty results, failure, and unauthorized access.
  * Updated and reorganized test fixtures for improved test structure and coverage.

* **Chores**
  * Refactored imports and test utility code for consistency and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->