### PR TITLE
Readd the missing field, and fix the confusion with Github .size and gitlab storage_size

### DIFF
--- a/devdox/app/schemas/repo.py
+++ b/devdox/app/schemas/repo.py
@@ -35,8 +35,8 @@ class RepoBase(BaseModel):
     git_hosting: Optional[GitHostingProvider] = Field(
         None, description="Git hosting provider"
     )
-    language: Optional[List] = Field(
-        None, description="Primary programming language"
+    language: Optional[List[str]] = Field(
+        None, description="Primary programming languages"
     )
     size: Optional[int] = Field(None, description="Repository size in KB", ge=0)
     repo_created_at: Optional[datetime] = Field(

--- a/devdox/tests/unit_test/app/routes/test_repos.py
+++ b/devdox/tests/unit_test/app/routes/test_repos.py
@@ -38,7 +38,7 @@ class TestRepoRouter:
             is_private=True,
             visibility="private",
             git_hosting=GitHosting.GITHUB.value,
-            language="Python",
+            language=["Python"],
             size=512,
             repo_created_at=datetime.datetime.now(),
             repo_updated_at=datetime.datetime.now(),

--- a/devdox/tests/unit_test/app/schema/test_repo.py
+++ b/devdox/tests/unit_test/app/schema/test_repo.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+import datetime
 from types import SimpleNamespace
 
 import pytest
@@ -15,7 +15,10 @@ class TestGitLabRepoResponseTransformer:
         assert GitLabRepoResponseTransformer.derive_storage_size(None) is None
 
     def test_derive_storage_size_with_value(self):
-        statistics = {"storage_size": 1234}
+        statistics = {
+            "storage_size": 1234,
+            "repository_size": 1234
+        }
         assert GitLabRepoResponseTransformer.derive_storage_size(statistics) == 1234
 
     def test_derived_private_field_with_none(self):
@@ -31,7 +34,7 @@ class TestGitLabRepoResponseTransformer:
         )
 
     def test_transform_project_to_dict_basic(self):
-        now = datetime.utcnow()
+        now = datetime.datetime.now(datetime.UTC)
         project = SimpleNamespace(
             id=1,
             name="project",
@@ -63,8 +66,8 @@ class TestGitLabRepoResponseTransformer:
             "http_url_to_repo": "http://example.com",
             "path_with_namespace": "repo",
             "visibility": "internal",
-            "created_at": datetime.utcnow(),
-            "statistics": {"storage_size": 512},
+            "created_at": datetime.datetime.now(datetime.UTC),
+            "statistics": {"storage_size": 512, "repository_size": 512},
         }
         response = GitLabRepoResponseTransformer.from_git(data)
         assert isinstance(response, GitRepoResponse)
@@ -94,7 +97,7 @@ class TestGitLabRepoResponseTransformer:
 
 class TestGitHubRepoResponseTransformer:
     def test_transform_repository_to_dict(self):
-        now = datetime.utcnow()
+        now = datetime.datetime.now(datetime.UTC)
         repo = SimpleNamespace(
             id=1,
             name="repo",
@@ -117,7 +120,7 @@ class TestGitHubRepoResponseTransformer:
         assert GitHubRepoResponseTransformer.from_git(None) is None
 
     def test_from_github_dict_returns_expected_schema(self):
-        now = datetime.utcnow()
+        now = datetime.datetime.now(datetime.UTC)
         data = {
             "id": 99,
             "name": "gh-repo",


### PR DESCRIPTION
Summary:

- Re-added the missing fields and properties

- Introduced KB to Byte conversion, since Github API returns the size in KB, while Gitlab in Byte. Multiplying the KB instead of dividing the Gitlab is far better and does not lose its precision to division. 

- Discovered that github `.size` isnt the same as gitlab `.statistics.storage_size`, this is the storage size of the entire gitlab project, including extras files related to Gitlab, while `.size` got Github is just for the project the .git part, as Github does not expose such information in its APIs. So, the Gitlab equivalent is `.statistics.repository_size`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying multiple programming languages for repositories.
  * Introduced an optional field to indicate the relative path of a repository.

* **Bug Fixes**
  * Improved accuracy of repository size reporting for GitLab and GitHub repositories.

* **Tests**
  * Updated tests to reflect changes in the language field and repository size handling.
  * Enhanced test coverage for time handling and repository statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->