### PR TITLE
refactor: Introduce pagination metadata and make label search case-insensitive for the Get all git labels by label api 

### DIFF
--- a/devdox/app/routes/git_tokens.py
+++ b/devdox/app/routes/git_tokens.py
@@ -97,7 +97,7 @@ async def get_git_label_by_label(
     )
 
     return APIResponse.success(
-        message="Git labels retrieved successfully", data={"items": results}
+        message="Git labels retrieved successfully", data=results
     )
 
 

--- a/devdox/app/services/api_keys.py
+++ b/devdox/app/services/api_keys.py
@@ -13,7 +13,7 @@ from app.exceptions.exception_constants import (
     INVALID_APIKEY,
     UNIQUE_API_KEY_GENERATION_FAILED,
 )
-from app.repositories.api_key import TortoiseApiKeyStore
+from app.repositories.api_key import TortoiseApiKeyStore as ApiKeyStore
 from app.schemas.api_key import APIKeyCreate, APIKeyPublicResponse
 from app.services.git_tokens import mask_token
 from app.utils.auth import UserClaims
@@ -31,7 +31,7 @@ class APIKeyManager:
     DEFAULT_MAX_KEY_LENGTH = 32
     DEFAULT_PREFIX = "dvd_"
 
-    def __init__(self, api_key_store: TortoiseApiKeyStore):
+    def __init__(self, api_key_store: ApiKeyStore):
         self.api_key_store = api_key_store
 
     @staticmethod
@@ -75,7 +75,7 @@ class PostApiKeyService:
 
     def __init__(
         self,
-        api_key_store: TortoiseApiKeyStore,
+        api_key_store: ApiKeyStore,
         api_key_manager: APIKeyManager,
     ):
         self.api_key_store = api_key_store
@@ -84,7 +84,7 @@ class PostApiKeyService:
     @classmethod
     def with_dependency(
         cls,
-        api_key_store: Annotated[TortoiseApiKeyStore, Depends()],
+        api_key_store: Annotated[ApiKeyStore, Depends()],
     ) -> "PostApiKeyService":
 
         api_key_manager = APIKeyManager(api_key_store=api_key_store)
@@ -128,14 +128,14 @@ class RevokeApiKeyService:
 
     def __init__(
         self,
-        api_key_store: TortoiseApiKeyStore,
+        api_key_store: ApiKeyStore,
     ):
         self.api_key_store = api_key_store
 
     @classmethod
     def with_dependency(
         cls,
-        api_key_store: Annotated[TortoiseApiKeyStore, Depends()],
+        api_key_store: Annotated[ApiKeyStore, Depends()],
     ) -> "RevokeApiKeyService":
 
         return cls(
@@ -160,14 +160,14 @@ class GetApiKeyService:
 
     def __init__(
         self,
-        api_key_store: TortoiseApiKeyStore,
+        api_key_store: ApiKeyStore,
     ):
         self.api_key_store = api_key_store
 
     @classmethod
     def with_dependency(
         cls,
-        api_key_store: Annotated[TortoiseApiKeyStore, Depends()],
+        api_key_store: Annotated[ApiKeyStore, Depends()],
     ) -> "GetApiKeyService":
 
         return cls(

--- a/devdox/app/services/repository.py
+++ b/devdox/app/services/repository.py
@@ -13,9 +13,9 @@ from app.exceptions.exception_constants import (
     USER_RESOURCE_NOT_FOUND,
 )
 from models import Repo
-from app.repositories.git_label import TortoiseGitLabelStore
-from app.repositories.repo import TortoiseRepoStore
-from app.repositories.user import TortoiseUserStore
+from app.repositories.git_label import TortoiseGitLabelStore as GitLabelStore
+from app.repositories.repo import TortoiseRepoStore as RepoStore
+from app.repositories.user import TortoiseUserStore as UserStore
 from app.schemas.basic import RequiredPaginationParams
 from app.schemas.repo import GitRepoResponse, RepoResponse
 from app.utils.auth import UserClaims
@@ -27,8 +27,8 @@ from app.utils.repo_fetcher import RepoFetcher
 class RepoQueryService:
     def __init__(
         self,
-        repo_store=Depends(TortoiseRepoStore),
-        gl_store=Depends(TortoiseGitLabelStore),
+        repo_store=Depends(RepoStore),
+        gl_store=Depends(GitLabelStore),
     ):
         self.repo_store = repo_store
         self.gl_store = gl_store
@@ -64,8 +64,8 @@ class RepoQueryService:
 class RepoProviderService:
     def __init__(
         self,
-        label_store: TortoiseGitLabelStore = Depends(),
-        user_store: TortoiseUserStore = Depends(),
+        label_store: GitLabelStore = Depends(),
+        user_store: UserStore = Depends(),
         encryption: FernetEncryptionHelper = Depends(get_encryption_helper),
         git_fetcher: RepoFetcher = Depends(),
     ):
@@ -114,7 +114,7 @@ class RepoProviderService:
         return fetched_data["data_count"], transformed_response
 
 
-async def retrieve_user_by_id_or_die(store: TortoiseUserStore, user_id):
+async def retrieve_user_by_id_or_die(store: UserStore, user_id):
     retrieved_user_data = await store.get_by_user_id(user_id)
 
     if retrieved_user_data is None:
@@ -134,9 +134,9 @@ async def retrieve_git_label_by_id_and_user_or_die(store, id, user_id):
 class RepoManipulationService:
     def __init__(
         self,
-        label_store: TortoiseGitLabelStore = Depends(),
-        repo_store: TortoiseRepoStore = Depends(),
-        user_store: TortoiseUserStore = Depends(),
+        label_store: GitLabelStore = Depends(),
+        repo_store: RepoStore = Depends(),
+        user_store: UserStore = Depends(),
         encryption: FernetEncryptionHelper = Depends(get_encryption_helper),
         git_fetcher: RepoFetcher = Depends(),
     ):

--- a/devdox/tests/unit_test/app/routes/test_git_tokens.py
+++ b/devdox/tests/unit_test/app/routes/test_git_tokens.py
@@ -147,6 +147,7 @@ class TestGetGitLabelByLabelRouter:
     def override_git_label_service_label_exception(self):
         def _override():
             store = FakeGitLabelStore()
+            store.total_count = 1
             store.set_exception(
                 "get_by_user_id_and_label", ValueError("Simulated error")
             )

--- a/devdox/tests/unit_test/app/services/test_git_tokens_service.py
+++ b/devdox/tests/unit_test/app/services/test_git_tokens_service.py
@@ -115,13 +115,14 @@ class TestGetGitLabelService__GetGitLabelsByLabel:
             user_claims=self.user_claims,
             label="bug",
         )
-
-        assert result[0]["label"] == "bug"
-        assert result[0]["masked_token"] == "****1234"
+        
+        dict_res = result.get('items', {})
+        assert dict_res[0]["label"] == "bug"
+        assert dict_res[0]["masked_token"] == "****1234"
 
     async def test_get_git_labels_by_label_handles_store_exception(self):
         self.store.set_exception(
-            "get_by_user_id_and_label", ValueError("Simulated error")
+            "count_by_user_id_and_label", ValueError("Simulated error")
         )
 
         with pytest.raises(ValueError, match="Simulated error"):
@@ -138,7 +139,7 @@ class TestGetGitLabelService__GetGitLabelsByLabel:
             pagination=self.pagination, user_claims=self.user_claims, label="anything"
         )
 
-        assert result == []
+        assert result["items"] == []
 
     async def test_get_git_labels_by_label_applies_formatting(self):
         label = make_fake_git_label(
@@ -150,7 +151,7 @@ class TestGetGitLabelService__GetGitLabelsByLabel:
             pagination=self.pagination, user_claims=self.user_claims, label="bug"
         )
 
-        item = result[0]
+        item = result.get("items", {})[0]
         assert item["label"] == "bug"
         assert item["masked_token"] == "****abcd"
         assert "id" in item and "created_at" in item

--- a/devdox/tests/unit_test/test_doubles/app/repository/get_label_repository_doubles.py
+++ b/devdox/tests/unit_test/test_doubles/app/repository/get_label_repository_doubles.py
@@ -42,7 +42,13 @@ class FakeGitLabelStore(ILabelStore):
             raise self.exceptions["count_by_user_id"]
         self.received_calls.append(("count_by_user_id", user_id, git_hosting))
         return self.total_count
-
+    
+    async def count_by_user_id_and_label(self, user_id, label=None):
+        if "count_by_user_id_and_label" in self.exceptions:
+            raise self.exceptions["count_by_user_id_and_label"]
+        self.received_calls.append(("count_by_user_id_and_label", user_id, label))
+        return self.total_count
+    
     async def get_by_token_id_and_user(self, token_id, user_id):
         if "get_by_token_id_and_user" in self.exceptions:
             raise self.exceptions["get_by_token_id_and_user"]


### PR DESCRIPTION
Summary:

- `api_keys.py` changes: renamed alias for `TortoiseApiKeyStore` as `ApiKeyStore` to make it easier when traversing through the code.

- `repository.py` service changes: renamed alias for db store to make it easier when traversing through the code.

- Changed API to return the metadata for the count:
  - `git_label.py` repository changes: Introduced `count_by_user_id_and_label`

  - `git_tokens.py` route changes: Changed the return type to accommodate for the pagination metadata

  - `get_label_repository_doubles.py` changes: Introduced `count_by_user_id_and_label` to the `FakeGitLabelStore`

  - `git_tokens.py` services changes:
    - renamed alias for db stores to make it easier when traversing through the code.
    - Introduced pagination metadata

  - Fixed the tests that were effected by the changes to the API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved label search to support case-insensitive matching and partial label queries.
  * Added the ability to retrieve the total count of labels matching a user and label.

* **Bug Fixes**
  * Adjusted API responses for label queries to consistently include pagination metadata and return results in a standardized format.

* **Tests**
  * Updated and expanded tests to reflect changes in label search functionality and API response structure.
  * Enhanced test doubles to support new label counting methods.

* **Refactor**
  * Renamed several internal service and repository types for clarity and consistency in codebase.
  * Standardized type annotations and dependency injection parameters for API key and label services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->