### PR TITLE
Refactor: Create Repo should return id of inserted value

### DIFF
--- a/devdox/app/routes/repos.py
+++ b/devdox/app/routes/repos.py
@@ -46,9 +46,7 @@ async def get_repos(
     )
     return APIResponse.success(
         message=RESOURCE_RETRIEVED_SUCCESSFULLY,
-        data=RepoListResponse(total_count=total_count, repos=repo_responses).model_dump(
-            mode="json"
-        ),
+        data=RepoListResponse(total_count=total_count, repos=repo_responses)
     )
 
 
@@ -83,8 +81,11 @@ async def add_repo_from_git(
     user: UserClaims = Depends(get_authenticated_user),
     repo_service: RepoManipulationService = Depends(RepoManipulationService),
 ):
-    await repo_service.add_repo_from_provider(user, token_id, payload.relative_path)
-    return APIResponse.success("Repository added successfully")
+    repo_db_id = await repo_service.add_repo_from_provider(user, token_id, payload.relative_path)
+    return APIResponse.success(
+        "Repository added successfully",
+        data={"id": repo_db_id}
+    )
 
 
 @router.post(

--- a/devdox/app/services/repository.py
+++ b/devdox/app/services/repository.py
@@ -160,7 +160,7 @@ class RepoManipulationService:
 
     async def add_repo_from_provider(
         self, user_claims: UserClaims, token_id: str, relative_path: str
-    ) -> None:
+    ) -> str:
 
         retrieved_user_data = await retrieve_user_by_id_or_die(
             self.user_store, user_claims.sub
@@ -184,7 +184,7 @@ class RepoManipulationService:
         transformed_data: GitRepoResponse = fetcher_data_mapper.from_git(repo_data)
 
         try:
-            _ = await self.repo_store.create_new_repo(
+            saved_repo = await self.repo_store.create_new_repo(
                 Repo(
                     user_id=user_claims.sub,
                     token_id=token_id,
@@ -203,6 +203,8 @@ class RepoManipulationService:
                     language=languages,
                 )
             )
+            
+            return str(saved_repo.id)
 
         except IntegrityError:
             raise BadRequest(reason=REPOSITORY_ALREADY_EXISTS)


### PR DESCRIPTION
Summary:
- Made Create repo return id of inserted record
- removed this since it's not required to be called inside the router anymore, it's already handled in the API response:
```
.model_dump(
            mode="json"
        ),
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * When adding a new repository, the response now includes the repository's unique ID.
* **Refactor**
  * Improved the structure of responses for repository-related endpoints for greater clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->