### PR TITLE
feat: Expose fields in API

### DIFF
--- a/devdox/app/routes/repos.py
+++ b/devdox/app/routes/repos.py
@@ -81,7 +81,7 @@ async def add_repo_from_git(
     user: UserClaims = Depends(get_authenticated_user),
     repo_service: RepoManipulationService = Depends(RepoManipulationService),
 ):
-    repo_db_id = await repo_service.add_repo_from_provider(user, token_id, payload.relative_path)
+    repo_db_id = await repo_service.add_repo_from_provider(user, token_id, payload)
     return APIResponse.success(
         "Repository added successfully",
         data={"id": repo_db_id}

--- a/devdox/app/schemas/repo.py
+++ b/devdox/app/schemas/repo.py
@@ -347,16 +347,16 @@ class AddRepositoryRequest(BaseModel):
         ),
     )
 
-    repo_alias_name: str = Field(
-        None,
+    repo_alias_name: Optional[str] = Field(
+        default=None,
         title=REPO_ALIAS_NAME_FIELD_TITLE,
         description=REPO_ALIAS_NAME_FIELD_DESCRIPTION,
         min_length=1,
         max_length=100,
     )
 
-    repo_user_reference: str = Field(
-        None,
+    repo_user_reference: Optional[str] = Field(
+        default=None,
         title=REPO_USER_REFERENCE_FIELD_TITLE,
         description=REPO_USER_REFERENCE_FIELD_DESCRIPTION,
         max_length=2000,

--- a/devdox/app/schemas/repo.py
+++ b/devdox/app/schemas/repo.py
@@ -347,14 +347,14 @@ class AddRepositoryRequest(BaseModel):
         ),
     )
 
-    repo_alias_name: Optional[str] = Field(
-        default=None,
+    repo_alias_name: str = Field(
+        ...,
         title=REPO_ALIAS_NAME_FIELD_TITLE,
         description=REPO_ALIAS_NAME_FIELD_DESCRIPTION,
         min_length=1,
         max_length=100,
     )
-
+    
     repo_user_reference: Optional[str] = Field(
         default=None,
         title=REPO_USER_REFERENCE_FIELD_TITLE,

--- a/devdox/app/schemas/repo.py
+++ b/devdox/app/schemas/repo.py
@@ -11,6 +11,24 @@ from datetime import datetime
 from enum import Enum
 
 
+
+REPO_ALIAS_NAME_FIELD_TITLE="Repository Alias Name"
+REPO_ALIAS_NAME_FIELD_DESCRIPTION="A user-defined alias for this repository, used locally within this system as an alternative to the official GitHub or GitLab repository name."
+
+REPO_USER_REFERENCE_FIELD_TITLE = "Repository User Reference Note"
+REPO_USER_REFERENCE_FIELD_DESCRIPTION = "An optional free-form description or note for this repository. Use this to explain its purpose, provide internal context, or document team-specific information."
+
+REPO_SYSTEM_REFERENCE_FIELD_TITLE= "Repository System generated Reference Note"
+REPO_SYSTEM_REFERENCE_FIELD_DESCRIPTION= "An optional description or note for this repository. System generates this to explain its purpose, provide internal context, or document specific information."
+
+
+class GitHostingProvider(str, Enum):
+    """Supported Git hosting providers"""
+
+    GITHUB = "github"
+    GITLAB = "gitlab"
+
+
 class RepoBase(BaseModel):
     """Base repository schema with common fields"""
 
@@ -44,6 +62,27 @@ class RepoBase(BaseModel):
         default=None,
         description="The path to the repository relative to its hosting platform domain",
         max_length=255,
+    )
+
+    repo_alias_name: Optional[str] = Field(
+        None,
+        title=REPO_ALIAS_NAME_FIELD_TITLE,
+        description=REPO_ALIAS_NAME_FIELD_DESCRIPTION,
+        min_length=1,
+        max_length=100,
+    )
+
+    repo_user_reference: Optional[str] = Field(
+        None,
+        title=REPO_USER_REFERENCE_FIELD_TITLE,
+        description=REPO_USER_REFERENCE_FIELD_DESCRIPTION,
+        max_length=2000,
+    )
+
+    repo_system_reference: Optional[str] = Field(
+        None,
+        title=REPO_SYSTEM_REFERENCE_FIELD_TITLE,
+        description=REPO_SYSTEM_REFERENCE_FIELD_DESCRIPTION
     )
 
 
@@ -308,11 +347,26 @@ class AddRepositoryRequest(BaseModel):
         ),
     )
 
+    repo_alias_name: str = Field(
+        None,
+        title=REPO_ALIAS_NAME_FIELD_TITLE,
+        description=REPO_ALIAS_NAME_FIELD_DESCRIPTION,
+        min_length=1,
+        max_length=100,
+    )
+
+    repo_user_reference: str = Field(
+        None,
+        title=REPO_USER_REFERENCE_FIELD_TITLE,
+        description=REPO_USER_REFERENCE_FIELD_DESCRIPTION,
+        max_length=2000,
+    )
+
     model_config = {
         "json_schema_extra": {
             "examples": [
-                {"relative_path": "openai/gpt-4"},  # GitHub-style
-                {"relative_path": "mygroup/dev/backend-api"},  # GitLab-style
+                {"relative_path": "openai/gpt-4", "repo_alias_name": "My Custom Github Repo", "repo_user_reference": "My custom description"},  # GitHub-style
+                {"relative_path": "mygroup/dev/backend-api", "repo_alias_name": "My Custom Gitlab Repo", "repo_user_reference": "My custom description"},  # GitLab-style
             ]
         }
     }

--- a/devdox/app/services/repository.py
+++ b/devdox/app/services/repository.py
@@ -20,7 +20,7 @@ from app.repositories.git_label import TortoiseGitLabelStore as GitLabelStore
 from app.repositories.repo import TortoiseRepoStore as RepoStore
 from app.repositories.user import TortoiseUserStore as UserStore
 from app.schemas.basic import RequiredPaginationParams
-from app.schemas.repo import GitRepoResponse, RepoResponse
+from app.schemas.repo import AddRepositoryRequest, GitRepoResponse, RepoResponse
 from app.utils.auth import UserClaims
 from app.utils.encryption import get_encryption_helper, FernetEncryptionHelper
 from app.utils.git_managers import retrieve_git_fetcher_or_die
@@ -159,7 +159,7 @@ class RepoManipulationService:
         self.repo_store = repo_store
 
     async def add_repo_from_provider(
-        self, user_claims: UserClaims, token_id: str, relative_path: str
+        self, user_claims: UserClaims, token_id: str, payload: AddRepositoryRequest
     ) -> str:
 
         retrieved_user_data = await retrieve_user_by_id_or_die(
@@ -178,7 +178,7 @@ class RepoManipulationService:
         )
 
         repo_data, languages = fetcher.fetch_single_repo(
-            decrypted_label_token, relative_path
+            decrypted_label_token, payload.relative_path
         )
 
         transformed_data: GitRepoResponse = fetcher_data_mapper.from_git(repo_data)
@@ -201,6 +201,8 @@ class RepoManipulationService:
                     size=transformed_data.size,
                     repo_created_at=transformed_data.repo_created_at,
                     language=languages,
+                    repo_alias_name=payload.repo_alias_name,
+                    repo_user_reference=payload.repo_user_reference
                 )
             )
             

--- a/devdox/pyproject.toml
+++ b/devdox/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "fastapi-cli==0.0.7",
     "starlette==0.46.2",
     "uvicorn==0.34.2",
-    #"uvloop==0.21.0",
+    "uvloop==0.21.0",
 
     #queue
     "tembo-pgmq-python==0.10.0",
@@ -46,7 +46,7 @@ dependencies = [
     "email_validator==2.2.0",
 
     #models
-    "models @ git+https://github.com/montymobile1/devdox-ai-models.git@430c9a1",
+    "models @ git+https://github.com/montymobile1/devdox-ai-models.git@00a32d2",
 
     # Encryption package
     "devdox-ai-encryption @ git+https://github.com/montymobile1/devdox-ai-encryption.git@4eefae1",

--- a/devdox/pyproject.toml
+++ b/devdox/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "fastapi-cli==0.0.7",
     "starlette==0.46.2",
     "uvicorn==0.34.2",
-    "uvloop==0.21.0",
+    #"uvloop==0.21.0",
 
     #queue
     "tembo-pgmq-python==0.10.0",
@@ -46,7 +46,7 @@ dependencies = [
     "email_validator==2.2.0",
 
     #models
-    "models @ git+https://github.com/montymobile1/devdox-ai-models.git@fe555c9",
+    "models @ git+https://github.com/montymobile1/devdox-ai-models.git@430c9a1",
 
     # Encryption package
     "devdox-ai-encryption @ git+https://github.com/montymobile1/devdox-ai-encryption.git@4eefae1",

--- a/devdox/tests/unit_test/app/routes/test_repos.py
+++ b/devdox/tests/unit_test/app/routes/test_repos.py
@@ -153,7 +153,7 @@ class TestAddRepoFromGit:
         app.dependency_overrides.clear()
 
     def test_add_repo_from_git(self, client):
-        payload = {"relative_path": "owner/repo"}
+        payload = {"relative_path": "owner/repo", "repo_alias_name": "some random alias"}
         headers = {"Authorization": "Bearer faketoken"}
         response = client.post(
             "/api/v1/repos/git_repos/users/token_abc", json=payload, headers=headers

--- a/devdox/tests/unit_test/app/services/test_repository_service.py
+++ b/devdox/tests/unit_test/app/services/test_repository_service.py
@@ -95,7 +95,7 @@ class TestRepoManipulationService:
         await service.add_repo_from_provider(
             claims,
             "t1",
-            payload=AddRepositoryRequest(relative_path="owner/repo"))
+            payload=AddRepositoryRequest(relative_path="owner/repo", repo_alias_name="some random alias"))
         assert service.repo_store.saved  # should have one saved repo
 
     @pytest.mark.asyncio
@@ -110,7 +110,7 @@ class TestRepoManipulationService:
         with pytest.raises(ResourceNotFound):
             await service.add_repo_from_provider(
                 UserClaims(sub="missing_user"), "t1", payload=AddRepositoryRequest(
-                    relative_path="p"
+                    relative_path="p", repo_alias_name="some random alias"
                 )
             )
 
@@ -125,7 +125,7 @@ class TestRepoManipulationService:
         )
         with pytest.raises(ResourceNotFound):
             await service.add_repo_from_provider(
-                UserClaims(sub="u1"), "missing_token", "p"
+                UserClaims(sub="u1"), "missing_token", AddRepositoryRequest(relative_path="p", repo_alias_name="some random alias")
             )
 
     @pytest.mark.asyncio
@@ -161,5 +161,5 @@ class TestRepoManipulationService:
             await service.add_repo_from_provider(
                 UserClaims(sub="u1"),
                 "t1",
-                payload=AddRepositoryRequest(relative_path="p")
+                payload=AddRepositoryRequest(relative_path="p", repo_alias_name="some random alias")
             )

--- a/devdox/tests/unit_test/app/services/test_repository_service.py
+++ b/devdox/tests/unit_test/app/services/test_repository_service.py
@@ -3,7 +3,7 @@ from tortoise.exceptions import IntegrityError
 
 from models import Repo
 from app.services.repository import RepoManipulationService
-from app.schemas.repo import GitRepoResponse
+from app.schemas.repo import AddRepositoryRequest, GitRepoResponse
 from app.utils.auth import UserClaims
 from app.exceptions.local_exceptions import (
     BadRequest,
@@ -92,7 +92,10 @@ class TestRepoManipulationService:
             git_fetcher=StubFetcher(),
         )
         claims = UserClaims(sub="u1")
-        await service.add_repo_from_provider(claims, "t1", "owner/repo")
+        await service.add_repo_from_provider(
+            claims,
+            "t1",
+            payload=AddRepositoryRequest(relative_path="owner/repo"))
         assert service.repo_store.saved  # should have one saved repo
 
     @pytest.mark.asyncio
@@ -106,7 +109,9 @@ class TestRepoManipulationService:
         )
         with pytest.raises(ResourceNotFound):
             await service.add_repo_from_provider(
-                UserClaims(sub="missing_user"), "t1", "p"
+                UserClaims(sub="missing_user"), "t1", payload=AddRepositoryRequest(
+                    relative_path="p"
+                )
             )
 
     @pytest.mark.asyncio
@@ -153,4 +158,8 @@ class TestRepoManipulationService:
             git_fetcher=StubFetcher(),
         )
         with pytest.raises(BadRequest):
-            await service.add_repo_from_provider(UserClaims(sub="u1"), "t1", "p")
+            await service.add_repo_from_provider(
+                UserClaims(sub="u1"),
+                "t1",
+                payload=AddRepositoryRequest(relative_path="p")
+            )


### PR DESCRIPTION
Related Jira:
- https://montyholding.atlassian.net/browse/DAPA-100

Summary:
- increased the commit number of the model package in `pyproject.toml`

- added the fields `repo_alias_name`, `repo_user_reference`, `repo_system_reference` where adequate in  `devdox\app\schemas\repo.py` and `devdox\app\services\repository.py`

- Made the API [POST] `/git_repos/users/{token_id}` support `repo_alias_name`, `repo_user_reference`

- Made the API [GET] `/` Get all repos support `repo_alias_name`, `repo_user_reference` and `repo_system_reference`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can add repository alias names and provide user/system reference notes; Git hosting options for GitHub and GitLab are available.

* **Bug Fixes**
  * Repository add endpoint now accepts detailed repository payloads (including alias and references) in a single request.

* **Tests**
  * Unit and route tests updated to send the new payload format.

* **Chores**
  * Updated an internal dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->