### PR TITLE
fix: Removed the token_value max length

### DIFF
--- a/devdox/app/schemas/git_label.py
+++ b/devdox/app/schemas/git_label.py
@@ -21,7 +21,7 @@ class GitLabelBase(BaseModel):
     #     ..., description="Username for the git hosting service", max_length=100
     # )
     git_hosting: GitHosting = Field(..., description=GIT_HOSTING_FIELD_DESCRIPTION)
-    token_value: str = Field(..., description=TOKEN_VALUE_FIELD_DESCRIPTION, max_length=100)
+    token_value: str = Field(..., description=TOKEN_VALUE_FIELD_DESCRIPTION)
 
 
 class GitLabelUpdate(BaseModel):


### PR DESCRIPTION
Related jira ticket: https://montyholding.atlassian.net/browse/DAPA-101

token_value is an encoded value, when inserted to the DB, there is no limit, but in the schema, for some reason it was set to max length = 100. 

Now, when a token_value was encoded, it had more than 100, and thus is causing an issue when being handled in code. 

Fixed it by removing the limit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the character limit for the token value field in label-related forms and APIs. Users can now enter longer values without restriction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->