### PR TITLE
make is_active in saving api key

### DIFF
--- a/devdox/app/services/api_keys.py
+++ b/devdox/app/services/api_keys.py
@@ -130,6 +130,7 @@ class PostApiKeyService:
                 user_id=user_claims.sub,
                 api_key=result.hashed,
                 masked_api_key=result.masked,
+                is_active=True
             )
         )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API keys now carry an Active status; newly generated keys are active by default.
  * This enables clearer key state visibility in responses and prepares for streamlined enable/disable management.
  * Existing integrations continue to work without changes; behavior remains backward-compatible.
  * Users may notice an explicit active flag when viewing or retrieving API keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->