### PR TITLE
Dapa 107 return id in get api keys

### DIFF
--- a/devdox/app/schemas/api_key.py
+++ b/devdox/app/schemas/api_key.py
@@ -46,6 +46,7 @@ class APIKeyGetAllRequest:
         self.pagination = pagination
 
 class APIKeyPublicResponse(BaseModel):
+    id: uuid.UUID = Field(..., description="The unique identifier for the API key")
     masked_api_key: str = Field(..., description=MASKED_API_KEY_FIELD_DESCRIPTION)
     created_at: datetime.datetime = Field(..., description=CREATED_AT_FIELD_DESCRIPTION)
     last_used_at: Optional[datetime.datetime] = Field(

--- a/devdox/app/services/api_keys.py
+++ b/devdox/app/services/api_keys.py
@@ -130,6 +130,7 @@ class PostApiKeyService:
                 user_id=user_claims.sub,
                 api_key=result.hashed,
                 masked_api_key=result.masked,
+                is_active=True
             )
         )
 

--- a/devdox/tests/unit_test/app/routes/test_api_keys_route.py
+++ b/devdox/tests/unit_test/app/routes/test_api_keys_route.py
@@ -121,6 +121,7 @@ class TestGetApiKeyRouter:
                         masked_api_key="****abcd",
                         created_at=datetime.datetime.now(datetime.timezone.utc),
                         last_used_at=datetime.datetime.now(datetime.timezone.utc),
+                        id=uuid.uuid4(),
                     )
                 ]
             )

--- a/devdox/tests/unit_test/app/services/test_api_keys_service.py
+++ b/devdox/tests/unit_test/app/services/test_api_keys_service.py
@@ -189,6 +189,7 @@ class TestAPIKeyPublicResponse:
             masked_api_key="****abcd",
             created_at=now,
             last_used_at=now,
+            id=uuid4(),
         )
 
         assert response.masked_api_key == "****abcd"
@@ -200,6 +201,7 @@ class TestAPIKeyPublicResponse:
         response = APIKeyPublicResponse(
             masked_api_key="****abcd",
             created_at=now,
+            id=uuid4()
         )
 
         assert response.last_used_at is None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - API key responses now include a unique public ID visible in serialized outputs.
  - Newly created API keys are set active by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->