### PR TITLE
Dev 33 add the additional statues life cycle to devdox ai portal api

### DIFF
--- a/devdox/app/services/repository.py
+++ b/devdox/app/services/repository.py
@@ -4,6 +4,7 @@ from uuid import UUID, uuid4
 from devdox_ai_git.repo_fetcher import RepoFetcher
 from devdox_ai_git.schema.repo import NormalizedGitRepo
 from fastapi import Depends
+from models_src.models.repo import StatusTypes
 
 from app.exceptions import exception_constants
 from app.exceptions.base_exceptions import DevDoxAPIException
@@ -254,7 +255,17 @@ class RepoManipulationService:
         token_info = await retrieve_git_label_or_die(
             self.git_label_repository, repo_info.token_id, user_claims.sub
         )
-
+        
+        _ = await self.repo_repository.update_analysis_metadata_by_id(
+            id=str(repo_info.id),
+            status=StatusTypes.ANALYSIS_PENDING,
+            processing_end_time=repo_info.processing_end_time,
+            total_files=repo_info.total_files,
+            total_chunks=repo_info.total_chunks,
+            total_embeddings=repo_info.total_embeddings,
+        )
+        
+        
         payload = {
             "job_type": "analyze",
             "payload": {

--- a/devdox/pyproject.toml
+++ b/devdox/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "email_validator==2.2.0",
 
     #models
-    "devdox-ai-models @ git+https://github.com/montymobile1/devdox-ai-models.git@93fa32a",
+    "devdox-ai-models @ git+https://github.com/montymobile1/devdox-ai-models.git@DEV-35-add-a-statues-enum-for-the-property-on-evdox-ai-models-to-streamline-and-modularize-the-code-and-add-a-missing-column",
 
     # git
     "devdox-ai-git @ git+https://github.com/montymobile1/devdox-ai-git@e36ee1a",

--- a/devdox/pyproject.toml
+++ b/devdox/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "email_validator==2.2.0",
 
     #models
-    "devdox-ai-models @ git+https://github.com/montymobile1/devdox-ai-models.git@DEV-35-add-a-statues-enum-for-the-property-on-evdox-ai-models-to-streamline-and-modularize-the-code-and-add-a-missing-column",
+    "devdox-ai-models @ git+https://github.com/montymobile1/devdox-ai-models.git@202561c",
 
     # git
     "devdox-ai-git @ git+https://github.com/montymobile1/devdox-ai-git@e36ee1a",

--- a/devdox/pyproject.toml
+++ b/devdox/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "fastapi-cli==0.0.7",
     "starlette==0.46.2",
     "uvicorn==0.34.2",
-    "uvloop==0.21.0",
+    "uvloop==0.21.0;sys_platform != 'win32'",
 
     #queue
     "tembo-pgmq-python==0.10.0",

--- a/devdox/tests/unit_test/app/services/test_repository_service.py
+++ b/devdox/tests/unit_test/app/services/test_repository_service.py
@@ -1,33 +1,24 @@
-import datetime
-import random
 import uuid
-
+from types import SimpleNamespace
 import pytest
-from devdox_ai_git.schema.repo import NormalizedGitRepo
-from github.AuthenticatedUser import AuthenticatedUser
-from models_src.dto.repo import GitHosting, RepoResponseDTO
-
-from app.exceptions.exception_constants import (
-    GIT_LABEL_TOKEN_RESOURCE_NOT_FOUND,
-    USER_RESOURCE_NOT_FOUND,
-)
-from models_src.dto.git_label import GitLabelResponseDTO
-from models_src.dto.user import UserResponseDTO
-from models_src.exceptions.utils import internal_error, RepoErrors
 
 from app.schemas.basic import RequiredPaginationParams
-from app.services.repository import RepoManipulationService, RepoQueryService
-from app.schemas.repo import AddRepositoryRequest
 from app.utils.auth import UserClaims
-from app.exceptions.local_exceptions import (
-    BadRequest,
-    ResourceNotFound,
-)
+from devdox_ai_git.schema.repo import NormalizedGitRepo
+from models_src.dto.repo import GitHosting, RepoRequestDTO
+from models_src.dto.git_label import GitLabelResponseDTO
+from models_src.dto.user import UserResponseDTO
+from models_src.exceptions.utils import RepoErrors
 from app.exceptions.base_exceptions import DevDoxAPIException
-from models_src.test_doubles.repositories.git_label import FakeGitLabelStore, StubGitLabelStore
-from models_src.test_doubles.repositories.repo import FakeRepoStore
-from models_src.test_doubles.repositories.user import StubUserStore
+from app.exceptions.local_exceptions import ResourceNotFound
+from app.exceptions import exception_constants
+from models_src.models.repo import StatusTypes
+import app.services.repository as repo_mod
 
+
+# -------------------------
+# Test Doubles / Stubs
+# -------------------------
 
 class StubEncryption:
     def decrypt_for_user(self, encrypted, salt_b64):
@@ -38,10 +29,14 @@ class StubEncryption:
 
 
 class StubTransformer:
+    def __init__(self, name_seed="test"):
+        self._name_seed = name_seed
+
     def from_git(self, data):
+        # "data" can be any object; we just produce a stable NormalizedGitRepo
         return NormalizedGitRepo(
-            id="r1",
-            repo_name="test",
+            id=str(uuid.uuid4()),
+            repo_name=f"{self._name_seed}",
             description=None,
             html_url="url",
             default_branch="main",
@@ -56,282 +51,419 @@ class StubTransformer:
 
 
 class StubFetcher:
-    
-    def __init__(self):
+    """
+    Minimal fetcher that cooperates with retrieve_git_fetcher_or_die()
+    by exposing get_components(provider) -> (fetcher, transformer).
+    Also implements the calls used by services.
+    """
+    def __init__(self, supported=(GitHosting.GITHUB.value, GitHosting.GITLAB.value), name_seed="test"):
+        self.supported = set(supported)
         self.provider = None
-    
+        self._name_seed = name_seed
+        self.fetch_user_repositories_calls = []
+        self.fetch_single_repo_calls = []
+        self.fetch_repo_user_calls = []
+
+        # Defaults (override per-test if needed)
+        self._user_repos_payload = {"data_count": 0, "data": []}
+        self._single_repo_payload = (object(), ["Python"])
+
+        # GitHub-like user object by default
+        class _GHEmail:
+            def __init__(self, email, primary, verified):
+                self.email = email
+                self.primary = primary
+                self.verified = verified
+
+        class _GHUser:
+            login = "octocat"
+            def get_emails(self):
+                return [
+                    _GHEmail("shadow@users.noreply.github.com", primary=False, verified=True),
+                    _GHEmail("octo@github.com", primary=True, verified=True),
+                ]
+
+        self._repo_user_github = _GHUser()
+        self._repo_user_gitlab = {"username": "labuser", "commit_email": "lab@users.noreply.gitlab.com"}
+
+    def set_user_repos_payload(self, payload: dict):
+        self._user_repos_payload = payload
+
+    def set_single_repo_payload(self, repo_obj, langs):
+        self._single_repo_payload = (repo_obj, langs)
+
     def get_components(self, provider):
         self.provider = provider
-        if provider in [GitHosting.GITLAB.value, GitHosting.GITHUB.value]:
-            return self, StubTransformer()
+        if provider in self.supported:
+            return self, StubTransformer(name_seed=self._name_seed)
         return None, None
 
+    # Used by RepoProviderService
+    def fetch_user_repositories(self, token, offset, limit):
+        self.fetch_user_repositories_calls.append((token, offset, limit))
+        return self._user_repos_payload
+
+    # Used by RepoManipulationService.add_repo_from_provider (not directly tested here)
     def fetch_single_repo(self, token, relative_path):
-        return object(), ["Python"]
+        self.fetch_single_repo_calls.append((token, relative_path))
+        return self._single_repo_payload
 
-    
-class TestRepoManipulationService:
+    def fetch_repo_user(self, token):
+        self.fetch_repo_user_calls.append(token)
+        if self.provider == GitHosting.GITHUB.value:
+            return self._repo_user_github
+        return self._repo_user_gitlab
+
+
+class CapturingRepoStore:
+    """Minimal repo store for analyze_repo and save calls."""
+    def __init__(self):
+        self.saved = []
+        self.by_id_result = None
+        self.by_id_exception = None
+        self.updated = []
+        self.count_by_user = 0
+        self.find_all = []
+
+    async def save(self, dto: RepoRequestDTO):
+        self.saved.append(dto)
+        return SimpleNamespace(id=uuid.uuid4())
+
+    async def get_by_id(self, _id):
+        if self.by_id_exception:
+            raise self.by_id_exception
+        return self.by_id_result
+
+    async def update_analysis_metadata_by_id(self, **kwargs):
+        self.updated.append(kwargs)
+        return True
+
+    async def count_by_user_id(self, user_id: str) -> int:
+        return self.count_by_user
+
+    async def find_all_by_user_id(self, user_id: str, offset: int, limit: int):
+        return self.find_all
+
+
+class StubUserStore:
+    def __init__(self):
+        self.result = None
+        self.exc = None
+
+    def set_output(self, val):
+        self.result = val
+
+    def set_exception(self, exc: Exception):
+        self.exc = exc
+
+    async def find_by_user_id(self, user_id: str):
+        if self.exc:
+            raise self.exc
+        return self.result
+
+
+class StubGitLabelStore:
+    def __init__(self):
+        self.by_id_user = None
+
+    def set_output(self, val):
+        self.by_id_user = val
+
+    async def find_by_token_id_and_user(self, token_id: str, user_id: str):
+        return self.by_id_user
+
+    async def find_git_hostings_by_ids(self, token_ids):
+        # For RepoQueryService tests you already wrote; not needed here
+        return []
+
+
+# -------------------------
+# RepoProviderService.get_all_provider_repos
+# -------------------------
+
+class TestRepoProviderService_GetAllProviderRepos:
 
     @pytest.mark.asyncio
-    async def test_add_repo_user_not_found(self):
-
-        fake_repo_repository = FakeRepoStore()
-        stub_git_label_store = StubGitLabelStore()
-
-        stub_git_label_store.set_output(
-            stub_git_label_store.find_by_token_id_and_user,
-            output=GitLabelResponseDTO(
-                token_value="encrypted_token", git_hosting=GitHosting.GITHUB.value
-            ),
-        )
-
-        stub_user_store = StubUserStore()
-        stub_user_store.set_exception(
-            stub_user_store.find_by_user_id,
-            ResourceNotFound(reason=USER_RESOURCE_NOT_FOUND)
-        )
-
-        service = RepoManipulationService(
-            git_label_repository=stub_git_label_store,
-            repo_repository=fake_repo_repository,
-            user_repository=stub_user_store,
+    async def test_user_not_found(self):
+        user_store = StubUserStore()  # returns None
+        label_store = StubGitLabelStore()
+        fetcher = StubFetcher()
+        service = repo_mod.RepoProviderService(
+            git_label_repository=label_store,
+            user_repository=user_store,
             encryption=StubEncryption(),
-            git_fetcher=StubFetcher(),
+            git_fetcher=fetcher,
         )
+
         with pytest.raises(ResourceNotFound):
-            await service.add_repo_from_provider(
-                UserClaims(sub="missing_user"), "t1", AddRepositoryRequest(relative_path="p", repo_alias_name="xyz")
+            await service.get_all_provider_repos(
+                token_id="t1",
+                user_claims=UserClaims(sub="u1"),
+                pagination=RequiredPaginationParams(limit=10, offset=0),
             )
 
     @pytest.mark.asyncio
-    async def test_add_repo_label_not_found(self):
+    async def test_label_not_found(self):
+        user_store = StubUserStore()
+        user_store.set_output(UserResponseDTO(encryption_salt="salt=="))
 
-        fake_repo_repository = FakeRepoStore()
-        stub_git_label_store = StubGitLabelStore()
+        label_store = StubGitLabelStore()  # returns None
+        fetcher = StubFetcher()
 
-        stub_git_label_store.set_exception(
-            stub_git_label_store.find_by_token_id_and_user,
-            ResourceNotFound(reason=GIT_LABEL_TOKEN_RESOURCE_NOT_FOUND)
-        )
-
-        
-
-        stub_user_store = StubUserStore()
-        stub_user_store.set_output(
-            stub_user_store.find_by_user_id,
-            output=UserResponseDTO(encryption_salt="salt=="),
-        )
-
-        service = RepoManipulationService(
-            git_label_repository=stub_git_label_store,
-            repo_repository=fake_repo_repository,
-            user_repository=stub_user_store,
+        service = repo_mod.RepoProviderService(
+            git_label_repository=label_store,
+            user_repository=user_store,
             encryption=StubEncryption(),
-            git_fetcher=StubFetcher(),
+            git_fetcher=fetcher,
         )
+
         with pytest.raises(ResourceNotFound):
-            await service.add_repo_from_provider(
-                UserClaims(sub="u1"), "missing_token", AddRepositoryRequest(relative_path="p", repo_alias_name="xyz")
+            await service.get_all_provider_repos(
+                token_id="missing",
+                user_claims=UserClaims(sub="u1"),
+                pagination=RequiredPaginationParams(limit=10, offset=0),
             )
 
     @pytest.mark.asyncio
-    async def test_add_repo_unsupported_provider(self):
-        class BadFetcher(StubFetcher):
-            def get_components(self, provider):
-                return None, None
+    async def test_empty_fetch_returns_zero_and_empty_list(self):
+        user_store = StubUserStore()
+        user_store.set_output(UserResponseDTO(encryption_salt="salt=="))
 
-        fake_repo_repository = FakeRepoStore()
-        stub_git_label_store = StubGitLabelStore()
+        label_store = StubGitLabelStore()
+        label_store.set_output(GitLabelResponseDTO(
+            id=uuid.uuid4(), user_id="u1", label="L", git_hosting=GitHosting.GITHUB.value,
+            username="u", token_value="enc", masked_token="***"
+        ))
 
-        stub_git_label_store.set_output(
-            stub_git_label_store.find_by_token_id_and_user,
-            output=GitLabelResponseDTO(
-                token_value="encrypted_token", git_hosting=GitHosting.GITHUB.value
-            ),
-        )
+        fetcher = StubFetcher()
+        fetcher.set_user_repos_payload({"data_count": 0, "data": []})
 
-        stub_user_store = StubUserStore()
-        stub_user_store.set_output(
-            stub_user_store.find_by_user_id,
-            output=UserResponseDTO(encryption_salt="salt=="),
-        )
-
-        service = RepoManipulationService(
-            git_label_repository=stub_git_label_store,
-            repo_repository=fake_repo_repository,
-            user_repository=stub_user_store,
+        service = repo_mod.RepoProviderService(
+            git_label_repository=label_store,
+            user_repository=user_store,
             encryption=StubEncryption(),
-            git_fetcher=BadFetcher(),
+            git_fetcher=fetcher,
         )
+
+        total, items = await service.get_all_provider_repos(
+            token_id="t1",
+            user_claims=UserClaims(sub="u1"),
+            pagination=RequiredPaginationParams(limit=5, offset=0),
+        )
+
+        assert total == 0
+        assert items == []
+        assert fetcher.provider == GitHosting.GITHUB.value  # ensure correct provider flowed through
+
+    @pytest.mark.asyncio
+    async def test_happy_path_maps_results(self):
+        user_store = StubUserStore()
+        user_store.set_output(UserResponseDTO(encryption_salt="salt=="))
+
+        label_store = StubGitLabelStore()
+        label_store.set_output(GitLabelResponseDTO(
+            id=uuid.uuid4(), user_id="u1", label="L", git_hosting=GitHosting.GITLAB.value,
+            username="u", token_value="enc", masked_token="***"
+        ))
+
+        fetcher = StubFetcher(name_seed="mapped")
+        fetcher.set_user_repos_payload({"data_count": 2, "data": [object(), object()]})
+
+        service = repo_mod.RepoProviderService(
+            git_label_repository=label_store,
+            user_repository=user_store,
+            encryption=StubEncryption(),
+            git_fetcher=fetcher,
+        )
+
+        total, items = await service.get_all_provider_repos(
+            token_id="t1",
+            user_claims=UserClaims(sub="u1"),
+            pagination=RequiredPaginationParams(limit=5, offset=0),
+        )
+
+        assert total == 2
+        assert len(items) == 2
+        assert all(hasattr(x, "repo_name") and x.repo_name == "mapped" for x in items)
+
+
+# -------------------------
+# Helper functions
+# -------------------------
+
+class TestHelpers:
+
+    @pytest.mark.asyncio
+    async def test_retrieve_user_by_id_or_die_ok(self):
+        user_store = StubUserStore()
+        user_store.set_output(UserResponseDTO(encryption_salt="salt=="))
+        res = await repo_mod.retrieve_user_by_id_or_die(user_store, "u1")
+        assert res.encryption_salt == "salt=="
+
+    @pytest.mark.asyncio
+    async def test_retrieve_user_by_id_or_die_not_found(self):
+        user_store = StubUserStore()  # returns None
+        with pytest.raises(ResourceNotFound):
+            await repo_mod.retrieve_user_by_id_or_die(user_store, "u1")
+
+    @pytest.mark.asyncio
+    async def test_retrieve_git_label_or_die_ok(self):
+        label_store = StubGitLabelStore()
+        label_store.set_output(SimpleNamespace(id="t1", user_id="u1"))
+        res = await repo_mod.retrieve_git_label_or_die(label_store, "t1", "u1")
+        assert res.id == "t1"
+
+    @pytest.mark.asyncio
+    async def test_retrieve_git_label_or_die_not_found(self):
+        label_store = StubGitLabelStore()  # returns None
+        with pytest.raises(ResourceNotFound):
+            await repo_mod.retrieve_git_label_or_die(label_store, "t1", "u1")
+
+    @pytest.mark.asyncio
+    async def test_retrieve_repo_by_id_translates_models_exception(self, monkeypatch):
+        # Create a lightweight dummy that will be caught by the service module's except block
+        class DummyDevDoxModelsException(Exception):
+            def __init__(self, error_type):
+                super().__init__("dummy")
+                self.error_type = error_type
+
+        # Swap the imported class inside the module so "except DevDoxModelsException" matches.
+        monkeypatch.setattr(repo_mod, "DevDoxModelsException", DummyDevDoxModelsException, raising=True)
+
+        repo_store = CapturingRepoStore()
+        repo_store.by_id_exception = DummyDevDoxModelsException(
+            RepoErrors.REPOSITORY_DOESNT_EXIST.value["error_type"]
+        )
+
         with pytest.raises(DevDoxAPIException) as exc:
-            await service.add_repo_from_provider(UserClaims(sub="u1"), "t1", AddRepositoryRequest(relative_path="p", repo_alias_name="xyz"))
+            await repo_mod.retrieve_repo_by_id(repo_store, "r1")
 
-        assert exc
+        # Optional: check it used the constants you expect
+        assert exc.value.error_type == exception_constants.REPOSITORY_DOESNT_EXIST_TITLE
 
-class TestRepoQueryService__GetAllUserRepositories:
-    
     @pytest.mark.asyncio
-    async def test_with_no_repo(self):
-        repo_store = FakeRepoStore()
-        fake_git_label_store = FakeGitLabelStore()
-        
-        service = RepoQueryService(
-            git_label_repository=fake_git_label_store,
-            repo_repository=repo_store
-        )
-        
-        result = await service.get_all_user_repositories(UserClaims(sub="u1"), RequiredPaginationParams(limit=10, offset=0))
-        
-        assert result == (0, [])
-    
+    async def test_retrieve_repo_by_id_none_raises_resource_not_found(self):
+        repo_store = CapturingRepoStore()
+        repo_store.by_id_result = None
+        with pytest.raises(ResourceNotFound):
+            await repo_mod.retrieve_repo_by_id(repo_store, "r1")
+
     @pytest.mark.asyncio
-    async def test_with_no_git_label_data(self):
-        user_claim = UserClaims(sub="1")
-        
-        repo_store = FakeRepoStore()
-        fake_git_label_store = FakeGitLabelStore()
-        
-        current_datetime = datetime.datetime.now(datetime.timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
-        
-        repo_fakes = []
-        
-        MAX_USER = 2
-        MAX_GIT_LABEL = 4
-        MAX_REPOS = 3
-        
-        for user_id in range(MAX_USER):
-            
-            clerk_id = user_id + 1
-            
-            for git_label in range(MAX_GIT_LABEL):
-                
-                random_git_hosting = random.choice(list(GitHosting))
-                random_git_hosting_value = random_git_hosting.value
-                
-                git_label_record = GitLabelResponseDTO(
-                    id=uuid.uuid4(),
-                    user_id=f"{clerk_id}",
-                    label=f"Label {clerk_id}-{git_label}",
-                    git_hosting=random_git_hosting_value,
-                    username=f"{random_git_hosting_value} username",
-                    token_value=f"Hashed {clerk_id}-{git_label} actual token",
-                    masked_token=f"Masked {clerk_id}-{git_label} actual token",
-                    created_at=current_datetime + datetime.timedelta(hours=git_label),
-                )
-                
-                for repo in range(MAX_REPOS):
-                    
-                    repo_record = RepoResponseDTO(
-                        id=uuid.uuid4(),
-                        user_id=f"{clerk_id}",
-                        repo_id=f"{clerk_id}-{git_label}-{repo}",
-                        repo_name=f"repo_name_{clerk_id}-{git_label}-{repo}",
-                        token_id=str(git_label_record.id),
-                        html_url=f"html_url_{clerk_id}-{git_label}-{repo}",
-                        default_branch=f"default_branch_{clerk_id}-{git_label}-{repo}",
-                        forks_count=1,
-                        stargazers_count=1,
-                        is_private=True,
-                        created_at=current_datetime + datetime.timedelta(hours=git_label),
-                        updated_at=current_datetime + datetime.timedelta(hours=git_label),
-                    )
-                    
-                    repo_fakes.append(repo_record)
-        
-        repo_store.set_fake_data(repo_fakes)
-        
-        service = RepoQueryService(
-            git_label_repository=fake_git_label_store,
-            repo_repository=repo_store
-        )
-        
-        LIMIT = 10
-        OFFSET = 0
-        
-        pagination = RequiredPaginationParams(limit=LIMIT, offset=OFFSET)
-        
-        result = await service.get_all_user_repositories(user_claim, pagination)
-        
-        assert result[0] == MAX_GIT_LABEL * MAX_REPOS
-        assert len(result[1]) == LIMIT
-        assert {(str(res.id), res.git_hosting) for res in result[1]} <= {(str(res.id), None) for res in repo_fakes}
-    
+    async def test_retrieve_repo_by_id_ok(self):
+        repo_store = CapturingRepoStore()
+        repo_store.by_id_result = SimpleNamespace(id="db-id", token_id="tok", default_branch="main")
+        res = await repo_mod.retrieve_repo_by_id(repo_store, "r1")
+        assert res.id == "db-id"
+
+
+# -------------------------
+# RepoManipulationService.analyze_repo
+# -------------------------
+
+class TestRepoManipulationService_AnalyzeRepo:
+
     @pytest.mark.asyncio
-    async def test_with_all_data(self):
-        user_claim = UserClaims(sub="1")
-        
-        repo_store = FakeRepoStore()
-        fake_git_label_store = FakeGitLabelStore()
-        
-        current_datetime = datetime.datetime.now(datetime.timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
-        
-        git_label_fakes = []
-        repo_fakes = []
-        
-        MAX_USER = 2
-        MAX_GIT_LABEL = 4
-        MAX_REPOS = 3
-        
-        for user_id in range(MAX_USER):
-            
-            clerk_id = user_id + 1
-            
-            for git_label in range(MAX_GIT_LABEL):
-                
-                random_git_hosting = random.choice(list(GitHosting))
-                random_git_hosting_value = random_git_hosting.value
-                
-                git_label_record = GitLabelResponseDTO(
-                    id=uuid.uuid4(),
-                    user_id=f"{clerk_id}",
-                    label=f"Label {clerk_id}-{git_label}",
-                    git_hosting=random_git_hosting_value,
-                    username=f"{random_git_hosting_value} username",
-                    token_value=f"Hashed {clerk_id}-{git_label} actual token",
-                    masked_token=f"Masked {clerk_id}-{git_label} actual token",
-                    created_at=current_datetime + datetime.timedelta(hours=git_label),
-                )
-                
-                git_label_fakes.append(git_label_record)
-                
-                for repo in range(MAX_REPOS):
-                    
-                    repo_record = RepoResponseDTO(
-                        id=uuid.uuid4(),
-                        user_id=f"{clerk_id}",
-                        repo_id=f"{clerk_id}-{git_label}-{repo}",
-                        repo_name=f"repo_name_{clerk_id}-{git_label}-{repo}",
-                        token_id=str(git_label_record.id),
-                        html_url=f"html_url_{clerk_id}-{git_label}-{repo}",
-                        default_branch=f"default_branch_{clerk_id}-{git_label}-{repo}",
-                        forks_count=1,
-                        stargazers_count=1,
-                        is_private=True,
-                        created_at=current_datetime + datetime.timedelta(hours=git_label),
-                        updated_at=current_datetime + datetime.timedelta(hours=git_label),
-                    )
-                    
-                    repo_fakes.append(repo_record)
-        
-        fake_git_label_store.set_fake_data(git_label_fakes)
-        repo_store.set_fake_data(repo_fakes)
-        
-        service = RepoQueryService(
-            git_label_repository=fake_git_label_store,
-            repo_repository=repo_store
+    async def test_analyze_repo_happy_path(self, monkeypatch):
+        # Arrange repo record
+        repo_store = CapturingRepoStore()
+        repo_store.by_id_result = SimpleNamespace(
+            id="db-id",
+            token_id="tok-1",
+            default_branch="main",
+            processing_end_time=None,
+            total_files=None,
+            total_chunks=None,
+            total_embeddings=None,
+            repo_id="provider-repo-id",
         )
-        
-        LIMIT = 10
-        OFFSET = 0
-        
-        pagination = RequiredPaginationParams(limit=LIMIT, offset=OFFSET)
-        
-        result = await service.get_all_user_repositories(user_claim, pagination)
-        
-        assert result[0] == MAX_GIT_LABEL * MAX_REPOS
-        assert len(result[1]) == LIMIT
-        
-        assert {str(res.id) for res in result[1]} <= {str(res.id) for res in repo_fakes}
-        assert all(res.git_hosting is not None for res in result[1])
-    
-    
+
+        # Git label / token info
+        label_store = StubGitLabelStore()
+        label_store.set_output(SimpleNamespace(
+            id="tok-1", token_value="enc-token", git_hosting="github"
+        ))
+
+        # Capture enqueues
+        calls = {"args": None}
+        class StubQueue:
+            async def enqueue(self, queue_name, payload, priority, job_type, user_id):
+                calls["args"] = (queue_name, payload, priority, job_type, user_id)
+                return True
+
+        # Patch the module-level supabase_queue symbol used by the method
+        monkeypatch.setattr(repo_mod, "supabase_queue", StubQueue(), raising=True)
+
+        service = repo_mod.RepoManipulationService(
+            git_label_repository=label_store,
+            repo_repository=repo_store,
+            user_repository=StubUserStore(),         # not used in analyze_repo
+            encryption=StubEncryption(),             # not used in analyze_repo
+            git_fetcher=StubFetcher(),               # not used in analyze_repo
+        )
+
+        await service.analyze_repo(UserClaims(sub="u1"), id="db-id")
+
+        # Assert update happened
+        assert repo_store.updated, "update_analysis_metadata_by_id should be called once"
+        upd = repo_store.updated[-1]
+        assert upd["id"] == "db-id"
+        assert upd["status"] == StatusTypes.ANALYSIS_PENDING
+
+        # Assert a job was enqueued with the expected shape
+        assert calls["args"] is not None
+        qname, payload, priority, job_type, user_id = calls["args"]
+        assert qname == "processing"
+        assert job_type == "analyze"
+        assert user_id == "u1"
+        assert payload["payload"]["git_provider"] == "github"
+        assert payload["payload"]["token_value"] == "enc-token"
+        assert payload["payload"]["repo_id"] == "provider-repo-id"
+
+    @pytest.mark.asyncio
+    async def test_analyze_repo_repo_missing_translates_models_exception(self, monkeypatch):
+        class DummyDevDoxModelsException(Exception):
+            def __init__(self, error_type):
+                super().__init__("dummy")
+                self.error_type = error_type
+
+        monkeypatch.setattr(repo_mod, "DevDoxModelsException", DummyDevDoxModelsException, raising=True)
+
+        repo_store = CapturingRepoStore()
+        repo_store.by_id_exception = DummyDevDoxModelsException(
+            RepoErrors.REPOSITORY_DOESNT_EXIST.value["error_type"]
+        )
+
+        service = repo_mod.RepoManipulationService(
+            git_label_repository=StubGitLabelStore(),
+            repo_repository=repo_store,
+            user_repository=StubUserStore(),
+            encryption=StubEncryption(),
+            git_fetcher=StubFetcher(),
+        )
+
+        with pytest.raises(DevDoxAPIException):
+            await service.analyze_repo(UserClaims(sub="u1"), id="does-not-exist")
+
+    @pytest.mark.asyncio
+    async def test_analyze_repo_token_missing_raises_resource_not_found(self, monkeypatch):
+        # Valid repo, but token lookup returns None → ResourceNotFound via retrieve_git_label_or_die
+        repo_store = CapturingRepoStore()
+        repo_store.by_id_result = SimpleNamespace(
+            id="db-id", token_id="tok-1",
+            default_branch="main", processing_end_time=None,
+            total_files=None, total_chunks=None, total_embeddings=None,
+            repo_id="provider-repo-id",
+        )
+
+        label_store = StubGitLabelStore()  # returns None
+
+        service = repo_mod.RepoManipulationService(
+            git_label_repository=label_store,
+            repo_repository=repo_store,
+            user_repository=StubUserStore(),
+            encryption=StubEncryption(),
+            git_fetcher=StubFetcher(),
+        )
+
+        with pytest.raises(ResourceNotFound):
+            await service.analyze_repo(UserClaims(sub="u1"), id="db-id")


### PR DESCRIPTION
Meta: 

related jira: https://montyholding.atlassian.net/browse/DEV-33
depends on pull request:
- https://github.com/montymobile1/devdox-ai-models/pull/21


----

added `;sys_platform != 'win32'` to automate the process of whether to isntall uvloop or not based on compatibility with the os that supports it, rather than having to manually remove it.

----

temporary changed to the temporary models package commit number, till its pushed

----

feat: added StatusTypes.ANALYSIS_PENDING when calling the analyze API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows platform compatibility.

* **Improvements**
  * Persist analysis metadata (status, timing, file/chunk/embedding counts) before queueing repository analysis jobs to improve processing reliability.

* **Tests**
  * Expanded unit tests: new test doubles, richer success/error coverage, and explicit tests verifying metadata update and job queuing behavior.

* **Chores**
  * Platform-restricted update to an asynchronous runtime dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->