### PR TITLE
Update dependencies: Bump FastAPI to v0.120.1, Starlette to v0.49.1, …

### DIFF
--- a/devdox/pyproject.toml
+++ b/devdox/pyproject.toml
@@ -20,9 +20,9 @@ dependencies = [
     "aerich>=0.7.2",
     
     # FastAPI and web framework
-    "fastapi==0.115.12",
+    "fastapi==0.120.1",
     "fastapi-cli==0.0.7",
-    "starlette==0.46.2",
+    "starlette==0.49.1",
     "uvicorn==0.34.2",
     "uvloop==0.21.0;sys_platform != 'win32'",
 
@@ -47,7 +47,6 @@ dependencies = [
 
     #models
     "devdox-ai-models @ git+https://github.com/montymobile1/devdox-ai-models.git@7e06188",
-
     # git
     "devdox-ai-git @ git+https://github.com/montymobile1/devdox-ai-git@e36ee1a",
 


### PR DESCRIPTION
…and update devdox-ai-models git reference.